### PR TITLE
Update Modulefile to work with other modules requiring stdlib

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,6 +1,6 @@
 name         'camptocamp-openssl'
 version      '0.1.0'
-dependency   'puppetlabs/stdlib', '0.0.1'
+dependency   'puppetlabs/stdlib', '>= 2.0.0'
 source       'https://github.com/camptocamp/puppet-openssl'
 author       'DevOps Team / Camptocamp'
 license      'GNU GPLv3'


### PR DESCRIPTION
Otherwise it actually breaks librarian-puppet from running normally in combination with other modules, that use puppet stdlib.
