### PR TITLE
Fix puppet-lint link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Please report bugs and feature request using [GitHub issue
 tracker](https://github.com/camptocamp/puppet-openssl/issues).
 
 For pull requests, it is very much appreciated to check your Puppet manifest
-with [puppet-lint](https://github.com/camptocamp/puppet-openssl/issues) to follow the recommended Puppet style guidelines from the
+with [puppet-lint](https://github.com/rodjek/puppet-lint) to follow the recommended Puppet style guidelines from the
 [Puppet Labs style guide](http://docs.puppetlabs.com/guides/style_guide.html).
 
 ## License


### PR DESCRIPTION
I think this is a typo.. Replaced old link by
https://github.com/rodjek/puppet-lint.
