### PR TITLE
Add cnf_tpl param to openssl::certificate::x509.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Advanced options:
       owner        => 'www-data',
       password     => 'j(D$',
       force        => false,
+      cnf_tpl      => 'my_module/cert.cnf.erb'
     }
 
 ### openssl::export::pkcs12

--- a/manifests/certificate/x509.pp
+++ b/manifests/certificate/x509.pp
@@ -20,6 +20,7 @@
 #  [*password*]       private key password
 #  [*force*]          whether to override certificate and request
 #                     if private key changes
+#  [*cnf_tpl*]        Specify an other template to generate ".cnf" file.
 #
 # === Example
 #
@@ -57,6 +58,7 @@ define openssl::certificate::x509(
   $owner = 'root',
   $password = undef,
   $force = true,
+  $cnf_tpl = 'openssl/cert.cnf.erb',
   ) {
 
   validate_string($name)
@@ -78,11 +80,12 @@ define openssl::certificate::x509(
   validate_bool($force)
   validate_re($ensure, '^(present|absent)$',
     "\$ensure must be either 'present' or 'absent', got '${ensure}'")
+  validate_string($cnf_tpl)
 
   file {"${base_dir}/${name}.cnf":
     ensure  => $ensure,
     owner   => $owner,
-    content => template('openssl/cert.cnf.erb'),
+    content => template($cnf_tpl),
   }
 
   ssl_pkey { "${base_dir}/${name}.key":


### PR DESCRIPTION
It may be useful to specify an other template for ".cnf" file
generated in openssl::certificate::x509.
