### PR TITLE
fixes exec: "...no path was specified..."

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -14,6 +14,7 @@ class openssl::packages {
 
     exec { 'update-ca-certificates':
       refreshonly => true,
+      path => " /usr/sbin",
       require     => Package['ca-certificates'],
     }
   }


### PR DESCRIPTION
err: Failed to apply catalog: 'update-ca-certificates' is not qualified and no path was specified. Please qualify the command or specify a path.

system:
debian wheezy, 
puppet 2.7.18
