### PR TITLE
Added certificate signing request dependency on configuration template

### DIFF
--- a/manifests/certificate/x509.pp
+++ b/manifests/certificate/x509.pp
@@ -100,6 +100,7 @@ define openssl::certificate::x509(
     days        => $days,
     password    => $password,
     force       => $force,
+    require     => File["${base_dir}/${name}.cnf"],
   }
 
   x509_request { "${base_dir}/${name}.csr":


### PR DESCRIPTION
Without this require, the manifest will sometimes fail if the .cnf template does not exist.  Adding it explicitly allows puppet to resolve dependencies on the first run every time.
