### PR TITLE
Fix bug with x509_Request not having the cnf template present

### DIFF
--- a/manifests/certificate/x509.pp
+++ b/manifests/certificate/x509.pp
@@ -113,6 +113,7 @@ define openssl::certificate::x509(
     private_key => "${base_dir}/${name}.key",
     password    => $password,
     force       => $force,
+    require     => File["${base_dir}/${name}.cnf"],
   }
 
   # Set owner of all files


### PR DESCRIPTION
Adding in additional require to x509_Request to ensure the template is created prior to executing
