### PR TITLE
File path change on rhel7

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,9 +10,9 @@ class openssl::params {
 
     'RedHat': {
       $ca_cert_path = $::operatingsystemmajrelease ? {
-        '4'     => '/usr/share/ssl/certs/ca-bundle.crt',
-        '5','6' => '/etc/pki/tls/certs/ca-bundle.crt',
-        default => '/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt',
+        '4'       => '/usr/share/ssl/certs/ca-bundle.crt',
+        /^(5|6)$/ => '/etc/pki/tls/certs/ca-bundle.crt',
+        default   => '/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt',
       }
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,7 +11,8 @@ class openssl::params {
     'RedHat': {
       $ca_cert_path = $::operatingsystemmajrelease ? {
         '4'     => '/usr/share/ssl/certs/ca-bundle.crt',
-        default => '/etc/pki/tls/certs/ca-bundle.crt',
+        '5','6' => '/etc/pki/tls/certs/ca-bundle.crt',
+        default => '/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt',
       }
     }
 


### PR DESCRIPTION
The ca-bundle.crt file is a symlink on RHEL7.
But:
On a fresh RHEL7 installation, the state is, in the "/etc/pki/tls/certs" directory:
lrwxrwxrwx. 1 root root 49 24 fév 13:51 ca-bundle.crt -> /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
lrwxrwxrwx. 1 root root 55 24 fév 13:51 ca-bundle.trust.crt -> /etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
Maybe we should take care of both files and symlinks ?