### PR TITLE
Add ability to generate a certificate authority and signed certs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,22 @@ openssl::export::pkcs12 { 'foo':
 }
 ```
 
+### openssl::certificate::authority
+
+This definition generates a self signed certificate to be used as a certificate authority:
+
+  openssl::certificate::authority { 'ca':
+    cnf_tpl       => 'my_module/openssl.cnf.erb',
+    base_dir      => '/etc/pki/mymodule,
+    country       => 'CH',
+    state         => 'Here',
+    locality      => 'Myplace',
+    organization  => 'Example.com',
+    commonname    => $fqdn,
+    days          => 365*20,
+  }
+
+
 ## Contributing
 
 Please report bugs and feature request using [GitHub issue

--- a/lib/puppet/provider/ssl_pkey/openssl.rb
+++ b/lib/puppet/provider/ssl_pkey/openssl.rb
@@ -28,6 +28,7 @@ Puppet::Type.type(:ssl_pkey).provide(:openssl) do
   end
 
   def exists?
+    return false if resource[:regenerate]
     Pathname.new(resource[:path]).exist?
   end
 

--- a/lib/puppet/type/ssl_pkey.rb
+++ b/lib/puppet/type/ssl_pkey.rb
@@ -29,4 +29,8 @@ Puppet::Type.newtype(:ssl_pkey) do
   newparam(:password) do
     desc 'The optional password for the key'
   end
+
+  newparam(:regenerate) do
+    desc 'Force a new key to be generated'
+  end
 end

--- a/lib/puppet/type/x509_cert.rb
+++ b/lib/puppet/type/x509_cert.rb
@@ -50,6 +50,10 @@ Puppet::Type.newtype(:x509_cert) do
     defaultto false
   end
 
+  newparam(:ca) do
+    desc 'If this certificate should be a self-signed Certificate Authority'
+  end
+
   newparam(:template) do
     desc 'The template to use'
     defaultto do
@@ -62,6 +66,26 @@ Puppet::Type.newtype(:x509_cert) do
         raise ArgumentError, "Path must be absolute: #{path}"
       end
     end
+  end
+
+  newparam(:request) do
+    desc 'The certificate signing request to use'
+    validate do |value|
+      path = Pathname.new(value)
+      unless path.absolute?
+        raise ArgumentError, "Path must be absolute: #{path}"
+      end
+    end
+  end
+
+  newparam(:server, :boolean => true) do
+    desc "If true, will generate a server only certificate"
+    defaultto(false)
+  end
+
+  newparam(:client, :boolean => true) do
+    desc "If true, will generate a client only certificate"
+    defaultto(false)
   end
 
   newparam(:authentication) do

--- a/lib/puppet/type/x509_request.rb
+++ b/lib/puppet/type/x509_request.rb
@@ -16,7 +16,7 @@ Puppet::Type.newtype(:x509_request) do
   newparam(:force, :boolean => true) do
     desc 'Whether to replace the certificate if the private key mismatches'
     newvalues(:true, :false)
-    defaultto false
+    defaultto true
   end
 
   newparam(:password) do

--- a/manifests/certificate/authority.pp
+++ b/manifests/certificate/authority.pp
@@ -1,0 +1,153 @@
+# == Definition: openssl::certificate::authority
+#
+# Creates a certificate authority and private key for signing certificates.
+#
+# === Parameters
+#  [*ensure*]         ensure wether certif and its config are present or not
+#  [*country*]        certificate countryName
+#  [*state*]          certificate stateOrProvinceName
+#  [*locality*]       certificate localityName
+#  [*common_name*]    certificate CommonName
+#  [*altnames*]       certificate subjectAltName.
+#                     Can be an array or a single string.
+#  [*organization*]   certificate organizationName
+#  [*unit*]           certificate organizationalUnitName
+#  [*email*]          certificate emailAddress
+#  [*days*]           certificate validity
+#  [*pki_dir*]       where cnf, crt, csr and key should be placed.
+#                     Directory must exist
+#  [*owner*]          cnf, crt, csr and key owner. User must exist
+#  [*group*]          cnf, crt, csr and key group. Group must exist
+#  [*password*]       private key password. undef means no passphrase 
+#                     will be used to encrypt private key.
+#  [*force*]          whether to override certificate and request
+#                     if private key changes
+#  [*cnf_tpl*]        Specify an other template to generate ".cnf" file.
+#
+# === Example
+#
+#   openssl::certificate::authority { 'ca':
+#     ensure       => present,
+#     country      => 'CH',
+#     organization => 'Example.com',
+#     common_name  => $fqdn,
+#     pki_dir      => '/var/www/ssl',
+#     owner        => 'www-data',
+#   }
+#
+# This will create files "foo.bar.cnf", "foo.bar.crt", "foo.bar.key"
+# and "foo.bar.csr" in /var/www/ssl/.
+# All files will belong to user "www-data".
+#
+# Those files can be used as is for apache, openldap and so on.
+#
+# === Requires
+#
+#   - `puppetlabs/stdlib`
+#
+define openssl::certificate::authority (
+  $country,
+  $organization,
+  $common_name,
+  $ensure = present,
+  $state = undef,
+  $locality = undef,
+  $unit = undef,
+  $altnames = [],
+  $email = undef,
+  $days = 365,
+  $pki_dir = '/etc/ssl/certs',
+  $owner = 'root',
+  $group = 'root',
+  $password = undef,
+  $force = true,
+  $cnf_tpl = 'openssl/openssl.cnf.erb',
+  ) {
+
+  validate_string($name)
+  validate_string($country)
+  validate_string($organization)
+  validate_string($commonname)
+  validate_string($ensure)
+  validate_string($state)
+  validate_string($locality)
+  validate_string($unit)
+  validate_array($altnames)
+  validate_string($email)
+  # lint:ignore:only_variable_string
+  validate_string("${days}")
+  validate_re("${days}", '^\d+$')
+  # lint:endignore
+  validate_string($pki_dir)
+  validate_string($owner)
+  validate_string($group)
+  validate_string($password)
+  validate_bool($force)
+  validate_re($ensure, '^(present|absent)$',
+    "\$ensure must be either 'present' or 'absent', got '${ensure}'")
+  validate_string($cnf_tpl)
+
+  file { $pki_dir:
+    ensure => directory,
+    owner   => $owner,
+    group   => $group,
+    mode    => '0700',
+  } ->
+  file { "${pki_dir}/${name}.cnf":
+    ensure  => $ensure,
+    owner   => $owner,
+    group   => $group,
+    content => template($cnf_tpl),
+  } ->
+  file { "${pki_dir}/index.txt":
+    ensure  => $ensure,
+    owner   => $owner,
+    group   => $group,
+    mode    => '0600',
+  } ->
+  file { "${pki_dir}/private":
+    ensure  => directory,
+    owner   => $owner,
+    group   => $group,
+    mode    => '0700',
+  } ->
+  file { "${pki_dir}/certs":
+    ensure  => directory,
+    owner   => $owner,
+    group   => $group,
+    mode    => '0700',
+  } ->
+  file { "${pki_dir}/requests":
+    ensure  => directory,
+    owner   => $owner,
+    group   => $group,
+    mode    => '0700',
+  } ->
+  ssl_pkey { "${pki_dir}/private/${name}_key.key": 
+    ensure => present,
+  } ~>
+  x509_cert { "${pki_dir}/certs/${name}_cert.crt":
+    ensure      => present,
+    ca          => true,
+    template    => "${pki_dir}/${name}.cnf",
+    private_key => "${pki_dir}/private/${name}_key.key",
+    force       => $force,
+    req_ext     => false,
+  }
+
+  # Set owner of all files
+  file { "${pki_dir}/${name}_key.key":
+    ensure  => $ensure,
+    owner   => $owner,
+    group   => $group,
+    mode    => '0600',
+    require => Ssl_pkey["${pki_dir}/private/${name}_key.key"],
+  }
+
+  file { "${pki_dir}/${name}_cert.crt":
+    ensure  => $ensure,
+    owner   => $owner,
+    group   => $group,
+    require => X509_cert["${pki_dir}/certs/${name}_cert.crt"],
+  }
+}

--- a/templates/openssl.cnf.erb
+++ b/templates/openssl.cnf.erb
@@ -1,0 +1,82 @@
+# file managed by puppet
+#
+# SSLeay example configuration file.
+#
+
+# This definition stops the following lines choking if HOME isn't
+# defined.
+dir = <%= @pki_dir %>
+
+[ ca ]
+default_ca = CA_default
+x509_extensions	= v3_ca
+
+[ CA_default ]
+serial         = $dir/serial
+database       = $dir/index.txt
+new_certs_dir  = $dir/certs
+private_key    = $dir/private/<%= @name %>_key.pem
+certificate    = $dir/certs/<%= @name %>_cert.pem
+default_md     = sha256
+default_days   = <%= @days %>
+
+preserve    = no
+email_in_dn = no
+policy      = policy_match
+nameopt     = default_ca
+certopt     = default_ca
+
+unique_subject  = no
+copy_extensions = none
+
+[ policy_match ]
+countryName            = match
+stateOrProvinceName    = match
+organizationName       = match
+organizationalUnitName = optional
+commonName             = supplied
+emailAddress           = optional
+
+[ req ]
+default_bits        = 2048
+default_keyfile     = privkey.pem
+distinguished_name  = req_distinguished_name
+req_extensions      = v3_req
+prompt              = no
+
+[ req_distinguished_name ]
+countryName            = <%= @country %>
+stateOrProvinceName    = <%= @state %>
+localityName           = <%= @locality %>
+organizationName       = <%= @organization %>
+<% unless @unit.nil? -%>
+organizationalUnitName = <%= @unit %>
+<% end -%>
+commonName             = <%= @common_name %>
+
+[ v3_ca ]
+basicConstraints        = CA:TRUE
+subjectKeyIdentifier    = hash
+authorityKeyIdentifier  = keyid:always,issuer:always
+nsCertType              = sslCA
+keyUsage                = cRLSign, keyCertSign
+extendedKeyUsage        = serverAuth, clientAuth
+ 
+[ v3_req ]
+basicConstraints     = CA:FALSE
+subjectKeyIdentifier = hash
+extendedKeyUsage     = serverAuth, clientAuth
+
+[ ssl_server ]
+basicConstraints        = CA:FALSE
+nsCertType              = server
+keyUsage                = digitalSignature, keyEncipherment
+extendedKeyUsage        = serverAuth, nsSGC, msSGC
+nsComment               = "OpenSSL Certificate for SSL Web Server"
+
+[ ssl_client ]
+basicConstraints        = CA:FALSE
+nsCertType              = client
+keyUsage                = digitalSignature, keyEncipherment
+extendedKeyUsage        = clientAuth
+nsComment               = "OpenSSL Certificate for SSL Client"


### PR DESCRIPTION
On the Katello project (https://github.com/Katello/katello) we currently use a python based tool to generate and manager certificates within a puppet module we maintain for generating and managing our certificates (https://github.com/Katello/puppet-certs). We'd like to switch to a more pure Puppet/Ruby implementation but we require the ability to generate a CA, manage the CA and allow the generating of certificates signed by the generated CA. 

The reason I mention the background is that I have got this addition to this point based on some initial testing and usage with our project and wanted to open this up for feedback.
