### PR TITLE
templates/cert.cnf.erb: Use sha256 instead of sha1 by default

### DIFF
--- a/templates/cert.cnf.erb
+++ b/templates/cert.cnf.erb
@@ -10,7 +10,7 @@ RANDFILE                = $ENV::HOME/.rnd
 
 [ req ]
 default_bits            = 2048
-default_md              = sha1
+default_md              = sha256
 default_keyfile         = privkey.pem
 distinguished_name      = req_distinguished_name
 prompt                  = no


### PR DESCRIPTION
SHA1 is now deprecated and showing warnings in modern browsers.  (Resolves #36)