### PR TITLE
Fix san use in certificate

### DIFF
--- a/lib/puppet/provider/x509_cert/openssl.rb
+++ b/lib/puppet/provider/x509_cert/openssl.rb
@@ -34,26 +34,17 @@ Puppet::Type.type(:x509_cert).provide(:openssl) do
   end
 
   def create
-    if resource[:password]
-      openssl(
-        'req',
-        '-config', resource[:template],
-        '-new', '-x509',
-        '-days', resource[:days],
-        '-key', resource[:private_key],
-        '-out', resource[:path],
-        '-passin', "pass:#{resource[:password]}"
-      )
-    else
-      openssl(
-        'req',
-        '-config', resource[:template],
-        '-new', '-x509',
-        '-days', resource[:days],
-        '-key', resource[:private_key],
-        '-out', resource[:path]
-      )
-    end
+    options = [
+      'req',
+      '-config', resource[:template],
+      '-new', '-x509',
+      '-days', resource[:days],
+      '-key', resource[:private_key],
+      '-out', resource[:path],
+    ]
+    options << ['-passin', "pass:#{resource[:password]}",] if resource[:password]
+    options << ['-extensions', "req_ext",] if resource[:req_ext] != :false
+    openssl options
   end
 
   def destroy

--- a/lib/puppet/type/x509_cert.rb
+++ b/lib/puppet/type/x509_cert.rb
@@ -44,6 +44,12 @@ Puppet::Type.newtype(:x509_cert) do
     desc 'The optional password for the private key'
   end
 
+  newparam(:req_ext, :boolean => true) do
+    desc 'Whether adding v3 SAN from config'
+    newvalues(:true, :false)
+    defaultto false
+  end
+
   newparam(:template) do
     desc 'The template to use'
     defaultto do

--- a/manifests/certificate/x509.pp
+++ b/manifests/certificate/x509.pp
@@ -21,7 +21,7 @@
 #  [*key_owner*]      key owner. User must exist. defaults to $owner
 #  [*key_group*]      key group. Group must exist. defaults to $group
 #  [*key_mode*]       key group.
-#  [*password*]       private key password. undef means no passphrase 
+#  [*password*]       private key password. undef means no passphrase
 #                     will be used to encrypt private key.
 #  [*force*]          whether to override certificate and request
 #                     if private key changes
@@ -103,6 +103,12 @@ define openssl::certificate::x509(
     "\$ensure must be either 'present' or 'absent', got '${ensure}'")
   validate_string($cnf_tpl)
 
+  if !empty($altnames) {
+    $req_ext = true
+  } else {
+    $req_ext = false
+  }
+
   file {"${base_dir}/${name}.cnf":
     ensure  => $ensure,
     owner   => $owner,
@@ -121,6 +127,7 @@ define openssl::certificate::x509(
     private_key => "${base_dir}/${name}.key",
     days        => $days,
     password    => $password,
+    req_ext     => $req_ext,
     force       => $force,
     require     => File["${base_dir}/${name}.cnf"],
   }

--- a/spec/unit/puppet/provider/x509_cert/openssl_spec.rb
+++ b/spec/unit/puppet/provider/x509_cert/openssl_spec.rb
@@ -21,25 +21,27 @@ describe 'The openssl provider for the x509_cert type' do
     end
 
     it 'should create a certificate with the proper options' do
-      subject.expects(:openssl).with(
+      subject.expects(:openssl).with([
         'req', '-config', '/tmp/foo.cnf', '-new', '-x509',
         '-days', 3650,
         '-key', '/tmp/foo.key',
-        '-out', '/tmp/foo.crt'
-      )
+        '-out', '/tmp/foo.crt',
+        ['-extensions', 'req_ext'],
+      ])
       subject.create
     end
 
     context 'when using password' do
       it 'should create a certificate with the proper options' do
         resource[:password] = '2x6${'
-        subject.expects(:openssl).with(
+        subject.expects(:openssl).with([
           'req', '-config', '/tmp/foo.cnf', '-new', '-x509',
           '-days', 3650,
           '-key', '/tmp/foo.key',
           '-out', '/tmp/foo.crt',
-          '-passin', 'pass:2x6${'
-        )
+          ['-passin', 'pass:2x6${'],
+          ['-extensions', 'req_ext'],
+        ])
         subject.create
       end
     end

--- a/spec/unit/puppet/type/x509_cert_spec.rb
+++ b/spec/unit/puppet/type/x509_cert_spec.rb
@@ -52,6 +52,17 @@ describe Puppet::Type.type(:x509_cert) do
     }.to raise_error(Puppet::Error, /Invalid value :foo/)
   end
 
+  it 'should accept a valid req_ext parameter' do
+    subject[:req_ext] = true
+    expect(subject[:req_ext]).to eq(:true)
+  end
+
+  it 'should not accept a bad req_ext parameter' do
+    expect {
+      subject[:req_ext] = :foo
+    }.to raise_error(Puppet::Error, /Invalid value :foo/)
+  end
+
   it 'should accept a valid authentication' do
     subject[:authentication] = :rsa
     expect(subject[:authentication]).to eq(:rsa)


### PR DESCRIPTION
Subject additional names were used inproperly.
Now we generate certificate with SAN's if they
were passed as an additional names to manifest.