### PR TITLE
Change cert existance logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :development, :unit_tests do
   gem 'rspec-puppet-facts',                                :require => false
   gem 'github_changelog_generator',                        :require => false, :git => 'https://github.com/raphink/github-changelog-generator.git', :branch => 'dev/all_patches' if RUBY_VERSION !~ /^1.8/
   gem 'puppet-blacksmith',                                 :require => false if RUBY_VERSION !~ /^1.8/
+  gem 'inifile'
 end
 
 group :system_tests do

--- a/lib/puppet/provider/x509_cert/openssl.rb
+++ b/lib/puppet/provider/x509_cert/openssl.rb
@@ -1,4 +1,5 @@
 require 'pathname'
+require 'inifile'
 Puppet::Type.type(:x509_cert).provide(:openssl) do
   desc 'Manages certificates with OpenSSL'
 
@@ -22,9 +23,34 @@ Puppet::Type.type(:x509_cert).provide(:openssl) do
     cert.check_private_key(priv)
   end
 
+  def self.old_cert_is_equal(resource)
+    cert = OpenSSL::X509::Certificate.new(File.read(resource[:path]))
+
+    altName = ''
+    cert.extensions.each do |ext|
+      altName = ext.value if ext.oid == 'subjectAltName'
+    end
+
+    cdata = {}
+    cert.subject.to_s.split('/').each do |name|
+      k,v = name.split('=')
+        cdata[k] = v
+    end
+
+    ini_file  = IniFile.load(resource[:template])
+    ini_file.each do |section, parameter, value|
+      return false if parameter == 'subjectAltName' and value.delete(' ').gsub(/^"|"$/, '') != altName.delete(' ').gsub(/^"|"$/, '')
+      return false if parameter == 'commonName' and value != cdata['CN']
+    end
+    return true
+  end
+
   def exists?
     if Pathname.new(resource[:path]).exist?
       if resource[:force] and !self.class.check_private_key(resource)
+        return false
+      end
+      if !self.class.old_cert_is_equal(resource)
         return false
       end
       return true

--- a/spec/unit/puppet/provider/x509_cert/openssl_spec.rb
+++ b/spec/unit/puppet/provider/x509_cert/openssl_spec.rb
@@ -11,7 +11,11 @@ describe 'The openssl provider for the x509_cert type' do
 
   context 'when not forcing key' do
     it 'exists? should return true if certificate exists and is synced' do
+      File.stubs(:read)
       Pathname.any_instance.expects(:exist?).returns(true)
+      c = OpenSSL::X509::Certificate.new # Fake certificate for mocking
+      OpenSSL::X509::Certificate.stubs(:new).returns(c)
+      IniFile.stubs(:load).returns([0,0,0])
       expect(subject.exists?).to eq(true)
     end
 
@@ -56,6 +60,7 @@ describe 'The openssl provider for the x509_cert type' do
       OpenSSL::X509::Certificate.stubs(:new).returns(c)
       OpenSSL::PKey::RSA.expects(:new)
       OpenSSL::X509::Certificate.any_instance.expects(:check_private_key).returns(true)
+      IniFile.stubs(:load).returns([0,0,0])
       expect(subject.exists?).to eq(true)
     end
 


### PR DESCRIPTION
Add checking commonName and subjectAltName in old certificate
if it exists. In other way we could not regenerate a new certificate
if any of these fields change.