### PR TITLE
dhparam: add

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,24 @@ This module provides three types and associated providers to manage SSL keys and
 
 In every case, not providing the password (or setting it to _undef_, which is the default) means that __the private key won't be encrypted__ with any symmetric cipher so __it is completely unprotected__.
 
+### dhparam
+
+This type allows to generate Diffie Hellman parameters.
+
+Simple usage:
+
+```puppet
+dhparam { '/path/to/dhparam.pem': }
+```
+
+Advanced options:
+
+```puppet
+dhparam { '/path/to/dhparam.pem':
+  size => 2048,
+}
+```
+
 ### ssl\_pkey
 
 This type allows to generate SSL private keys.
@@ -147,6 +165,41 @@ openssl::export::pkcs12 { 'foo':
   cert     => '/there/is/the/cert.crt',
   in_pass  => 'my_pkey_password',
   out_pass => 'my_pkcs12_password',
+}
+```
+
+### openssl::dhparam
+
+This definition creates a dhparam PEM file:
+
+
+Simple usage:
+
+```puppet
+openssl::dhparam { '/path/to/dhparam.pem': }
+```
+
+which is equivalent to:
+
+```puppet
+openssl::dhparam { '/path/to/dhparam.pem':
+  ensure => 'present',
+  size   => 512,
+  owner  => 'root',
+  group  => 'root',
+  mode   => '0644',
+}
+```
+
+Advanced usage:
+
+```puppet
+openssl::dhparam { '/path/to/dhparam.pem':
+  ensure => 'present',
+  size   => 2048,
+  owner  => 'www-data',
+  group  => 'adm',
+  mode   => '0640',
 }
 ```
 

--- a/lib/puppet/provider/dhparam/openssl.rb
+++ b/lib/puppet/provider/dhparam/openssl.rb
@@ -1,0 +1,23 @@
+require 'pathname'
+Puppet::Type.type(:dhparam).provide(:openssl) do
+  desc 'Manages dhparam files with OpenSSL'
+
+  commands :openssl => 'openssl'
+
+  def exists?
+    Pathname.new(resource[:path]).exist?
+  end
+
+  def create
+    options = [
+      'dhparam',
+      '-out', resource[:path],
+      resource[:size]
+    ]
+    openssl options
+  end
+
+  def destroy
+    Pathname.new(resource[:path]).delete
+  end
+end

--- a/lib/puppet/type/dhparam.rb
+++ b/lib/puppet/type/dhparam.rb
@@ -1,0 +1,27 @@
+require 'pathname'
+Puppet::Type.newtype(:dhparam) do
+  desc 'A Diffie Helman parameter file'
+
+  ensurable
+
+  newparam(:path, :namevar => true) do
+    validate do |value|
+      path = Pathname.new(value)
+      unless path.absolute?
+        raise ArgumentError, "Path must be absolute: #{path}"
+      end
+    end
+  end
+
+  newparam(:size) do
+    desc 'The key size'
+    newvalues /\d+/
+    defaultto 512
+    validate do |value|
+      size = value
+      if size <= 0 || size != size.to_i
+        raise ArgumentError, "Size must be a positive integer: #{size.inspect}"
+      end
+    end
+  end
+end

--- a/manifests/dhparam.pp
+++ b/manifests/dhparam.pp
@@ -1,0 +1,47 @@
+# == Definition: openssl::dhparam
+#
+# Creates Diffie Helman parameters.
+#
+# === Parameters
+#  [*path*]    path to write DH parameters to
+#  [*ensure*]  ensure whether DH paramers file is present or absent
+#  [*size*]    number of bits for the parameter set
+#  [*owner*]   file owner. User must exist
+#  [*group*]   file group. Group must exist
+#  [*mode*]    file mode.
+#
+# === Requires
+#
+#   - `puppetlabs/stdlib`
+#
+define openssl::dhparam(
+  $path,
+  $ensure = present,
+  $size = 512,
+  $owner = 'root',
+  $group = 'root',
+  $mode = '0644',
+) {
+
+  validate_absolute_path($path)
+  validate_re($ensure, '^(present|absent)$',
+    "\$ensure must be either 'present' or 'absent', got '${ensure}'")
+  validate_integer($size, '', 1) # positive integer
+  validate_string($owner)
+  validate_string($group)
+  validate_string($mode)
+
+  dhparam { $path:
+    ensure => $ensure,
+    size   => $size,
+  }
+
+  # Set file access
+  file { $path:
+      ensure  => $ensure,
+      owner   => $owner,
+      group   => $group,
+      mode    => $mode,
+      require => Dhparam[$path];
+  }
+}

--- a/spec/defines/openssl_dhparam_spec.rb
+++ b/spec/defines/openssl_dhparam_spec.rb
@@ -1,0 +1,130 @@
+require 'spec_helper'
+
+describe 'openssl::dhparam' do
+  let (:title) { '/etc/ssl/dhparam.pem' }
+
+  context 'when passing non absolute path' do
+    let (:params) { {
+      :path => 'foo',
+    } }
+    it 'should fail' do
+      expect {
+              is_expected.to contain_file('/etc/ssl/dhparam.pem')
+      }.to raise_error(Puppet::Error, /"foo" is not an absolute path/)
+    end
+  end
+  context 'when passing wrong value for ensure' do
+    let (:params) { {
+      :path => '/etc/ssl/dhparam.pem',
+      :ensure => 'foo',
+    } }
+    it 'should fail' do
+      expect {
+        is_expected.to contain_file('/etc/ssl/dhparam.pem')
+      }.to raise_error(Puppet::Error, /\$ensure must be either 'present' or 'absent', got 'foo'/)
+    end
+  end
+  context 'when passing non positive size' do
+    let (:params) { {
+      :path => '/etc/ssl/dhparam.pem',
+      :size => -1,
+    } }
+    it 'should fail' do
+      expect {
+        is_expected.to contain_file('/etc/ssl/dhparam.pem')
+      }.to raise_error(Puppet::Error, /Expected -1 to be greater or equal to 1, got -1/)
+    end
+  end
+  context 'when passing wrong type for user' do
+    let (:params) { {
+      :path => '/etc/ssl/dhparam.pem',
+      :owner => true,
+    } }
+    it 'should fail' do
+      expect {
+        is_expected.to contain_file('/etc/ssl/dhparam.pem')
+      }.to raise_error(Puppet::Error, /true is not a string/)
+    end
+  end
+  context 'when passing wrong type for group' do
+    let (:params) { {
+      :path => '/etc/ssl/dhparam.pem',
+      :group => true,
+    } }
+    it 'should fail' do
+      expect {
+        is_expected.to contain_file('/etc/ssl/dhparam.pem')
+      }.to raise_error(Puppet::Error, /true is not a string/)
+    end
+  end
+  context 'when passing wrong type for mode' do
+    let (:params) { {
+      :path => '/etc/ssl/dhparam.pem',
+      :mode => true,
+    } }
+    it 'should fail' do
+      expect {
+        is_expected.to contain_file('/etc/ssl/dhparam.pem')
+      }.to raise_error(Puppet::Error, /true is not a string/)
+    end
+  end
+  context 'when using defaults' do
+    let (:params) { {
+      :path => '/etc/ssl/dhparam.pem',
+    } }
+    it {
+      is_expected.to contain_dhparam('/etc/ssl/dhparam.pem').with(
+        :ensure => 'present',
+        :size => 512
+      )
+    }
+    it {
+      is_expected.to contain_file('/etc/ssl/dhparam.pem').with(
+        :ensure => 'present',
+        :owner  => 'root',
+        :group  => 'root',
+        :mode   => '0644'
+      )
+    }
+  end
+
+ context 'when passing all parameters' do
+    let (:params) { {
+      :path  => '/etc/ssl/dhparam.pem',
+      :owner => 'www-data',
+      :group => 'adm',
+      :mode  => '0640',
+      :size  => 2048
+    } }
+    it {
+      is_expected.to contain_dhparam('/etc/ssl/dhparam.pem').with(
+        :ensure => 'present',
+        :size   => 2048
+      )
+    }
+    it {
+      is_expected.to contain_file('/etc/ssl/dhparam.pem').with(
+        :ensure => 'present',
+        :owner => 'www-data',
+        :group => 'adm',
+        :mode => '0640'
+      )
+    }
+  end
+  context 'when absent' do
+    let (:params) { {
+      :path  => '/etc/ssl/dhparam.pem',
+      :ensure => 'absent',
+    } }
+    it {
+      is_expected.to contain_dhparam('/etc/ssl/dhparam.pem').with(
+        :ensure => 'absent'
+      )
+    }
+    it {
+      is_expected.to contain_file('/etc/ssl/dhparam.pem').with(
+        :ensure => 'absent'
+      )
+    }
+  end
+end

--- a/spec/unit/puppet/provider/dhparam/openssl_spec.rb
+++ b/spec/unit/puppet/provider/dhparam/openssl_spec.rb
@@ -1,0 +1,37 @@
+require 'puppet'
+require 'pathname'
+require 'puppet/type/dhparam'
+
+RSpec.configure { |c| c.mock_with :mocha }
+
+describe 'The openssl provider for the dhparam type' do
+  let (:path) { '/tmp/dhparam.pem' }
+  let (:resource) { Puppet::Type::Dhparam.new({:path => path}) }
+  subject { Puppet::Type.type(:dhparam).provider(:openssl).new(resource) }
+
+  context 'when using default size' do
+    it 'should create dhpram with the proper options' do
+      subject.expects(:openssl).with([
+        'dhparam',
+        '-out', '/tmp/dhparam.pem',
+        512
+      ])
+      subject.create
+    end
+  end
+  context 'when setting size' do
+    it 'should create dhpram with the proper options' do
+      resource[:size] = 2048
+      subject.expects(:openssl).with([
+        'dhparam',
+        '-out', '/tmp/dhparam.pem',
+        2048
+      ])
+      subject.create
+    end
+  end
+  it 'should delete file' do
+    Pathname.any_instance.expects(:delete)
+    subject.destroy
+  end
+end

--- a/spec/unit/puppet/type/dhparam_spec.rb
+++ b/spec/unit/puppet/type/dhparam_spec.rb
@@ -1,0 +1,37 @@
+require 'puppet'
+require 'puppet/type/dhparam'
+describe Puppet::Type.type(:dhparam) do
+  subject { Puppet::Type.type(:dhparam).new(:path => '/tmp/dhparam.pem') }
+
+  it 'should not accept a non absolute path' do
+    expect {
+      Puppet::Type.type(:dhparam).new(:path => 'foo')
+    }.to raise_error(Puppet::Error, /Path must be absolute: foo/)
+  end
+
+  it 'should accept ensure' do
+    subject[:ensure] = :present
+    expect(subject[:ensure]).to eq(:present)
+  end
+
+  it 'should accept valid size' do
+    subject[:size] = 2048
+    expect(subject[:size]).to eq(2048)
+  end
+
+  it 'should not accept a zero size' do
+    expect {
+      subject[:size] = 0
+    }.to raise_error(Puppet::Error, /Size must be a positive integer: 0/)
+  end
+  it 'should not accept an negative size' do
+    expect {
+      subject[:size] = -1
+    }.to raise_error(Puppet::Error, /Size must be a positive integer: -1/)
+  end
+  it 'should not accept a non-integer size' do
+    expect {
+      subject[:size] = 1.5
+    }.to raise_error(Puppet::Error, /Size must be a positive integer: 1.5/)
+  end
+end


### PR DESCRIPTION
You should be using a stronger-than-default dhparam for modern TLS configuration to mitigate https://weakdh.org/

This makes it easy to do so.