### PR TITLE
Add support for installing development lib for OpenSSL

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,17 +5,20 @@
 # === Parameters
 #  [*package_ensure*]           openssl package ensure
 #  [*ca_certificates_ensure*]   ca-certificates package ensure
+#  [*dev_package_ensure*]       dev package ensure (currently only Ubuntu)
 #
 # === Example
 #
 #   class { '::openssl':
 #     package_ensure         => latest,
 #     ca_certificates_ensure => latest,
+#     dev_package_ensure     => latest,
 #   }
 #
 class openssl (
   $package_ensure         = present,
   $ca_certificates_ensure = present,
+  $dev_package_ensure     = undef,
 ){
   class { '::openssl::packages': } ->
   Class['openssl']

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -6,6 +6,12 @@ class openssl::packages {
     ensure => $openssl::package_ensure,
   }
 
+  if $openssl::dev_package_ensure and $::osfamily == 'Debian' {
+    package { 'libssl-dev':
+      ensure => $openssl::dev_package_ensure,
+    }
+  }
+
   if $::osfamily == 'Debian' or (
   $::osfamily == 'RedHat' and versioncmp($::operatingsystemrelease, '6.0') >= 0) {
     ensure_packages(['ca-certificates'], {


### PR DESCRIPTION
This updates the OpenSSL class to also manage the installation of `libssl-dev`
when installing OpenSSL on a host. The reason for this is that some C extensions
which leverage OpenSSL perform a check that searches for the OpenSSL header to
be present (one example is Shopify's [semian](https://github.com/Shopify/semian/blob/master/ext/semian/extconf.rb#L16) project).

You'll also notice that this is only installed for the Debian OS family and the
reason is that I haven't researched the RedHat equivalent or know if it's even
required at all so before going down that rabbit hole, I thought I'd get this
working for our needs and we can revisit this at a later time if it's required. 
