### PR TITLE
Add argument key_size to openssl::certificate::x509

### DIFF
--- a/lib/puppet/provider/ssl_pkey/openssl.rb
+++ b/lib/puppet/provider/ssl_pkey/openssl.rb
@@ -9,9 +9,9 @@ Puppet::Type.type(:ssl_pkey).provide(:openssl) do
 
   def self.generate_key(resource)
     if resource[:authentication] == :dsa
-      OpenSSL::PKey::DSA.new(Integer(resource[:size]))
+      OpenSSL::PKey::DSA.new(resource[:size])
     elsif resource[:authentication] == :rsa
-      OpenSSL::PKey::RSA.new(Integer(resource[:size]))
+      OpenSSL::PKey::RSA.new(resource[:size])
     else
       raise Puppet::Error,
         "Unknown authentication type '#{resource[:authentication]}'"

--- a/lib/puppet/provider/ssl_pkey/openssl.rb
+++ b/lib/puppet/provider/ssl_pkey/openssl.rb
@@ -9,9 +9,9 @@ Puppet::Type.type(:ssl_pkey).provide(:openssl) do
 
   def self.generate_key(resource)
     if resource[:authentication] == :dsa
-      OpenSSL::PKey::DSA.new(resource[:size])
+      OpenSSL::PKey::DSA.new(Integer(resource[:size]))
     elsif resource[:authentication] == :rsa
-      OpenSSL::PKey::RSA.new(resource[:size])
+      OpenSSL::PKey::RSA.new(Integer(resource[:size]))
     else
       raise Puppet::Error,
         "Unknown authentication type '#{resource[:authentication]}'"

--- a/lib/puppet/type/ssl_pkey.rb
+++ b/lib/puppet/type/ssl_pkey.rb
@@ -24,6 +24,10 @@ Puppet::Type.newtype(:ssl_pkey) do
     desc 'The key size'
     newvalues /\d+/
     defaultto 2048
+
+    munge do |val|
+      val.to_i
+    end
   end
 
   newparam(:password) do

--- a/manifests/certificate/x509.pp
+++ b/manifests/certificate/x509.pp
@@ -88,6 +88,7 @@ define openssl::certificate::x509(
   $crt = undef,
   $csr = undef,
   $key = undef,
+  $key_size = 2048,
   $owner = 'root',
   $group = 'root',
   $key_owner = undef,
@@ -141,6 +142,10 @@ define openssl::certificate::x509(
   validate_absolute_path($_crt)
   validate_string($_key)
   validate_absolute_path($_key)
+  # lint:ignore:only_variable_string
+  validate_string("${key_size}")
+  validate_re("${key_size}", '^\d+$')
+  # lint:endignore
   validate_string($owner)
   validate_string($group)
   validate_string($_key_owner)
@@ -168,6 +173,7 @@ define openssl::certificate::x509(
   ssl_pkey { $_key:
     ensure   => $ensure,
     password => $password,
+    size     => $key_size,
   }
 
   x509_cert { $_crt:

--- a/spec/defines/openssl_certificate_x509_spec.rb
+++ b/spec/defines/openssl_certificate_x509_spec.rb
@@ -358,6 +358,7 @@ describe 'openssl::certificate::x509' do
       :altnames     => ['a.com', 'b.com', 'c.com'],
       :email        => 'contact@foo.com',
       :days         => 4567,
+      :key_size     => 4096,
       :owner        => 'www-data',
       :password     => '5r$}^',
       :force        => false,
@@ -390,7 +391,8 @@ describe 'openssl::certificate::x509' do
     it {
       is_expected.to contain_ssl_pkey('/tmp/foobar/foo.key').with(
         :ensure   => 'present',
-        :password => '5r$}^'
+        :password => '5r$}^',
+        :size     => 4096
       )
     }
 

--- a/spec/defines/openssl_certificate_x509_spec.rb
+++ b/spec/defines/openssl_certificate_x509_spec.rb
@@ -262,6 +262,21 @@ describe 'openssl::certificate::x509' do
     end
   end
 
+  context 'when passing wrong type for key_size' do
+    let (:params) { {
+      :country      => 'CH',
+      :organization => 'bar',
+      :commonname   => 'baz',
+      :base_dir     => '/tmp/foo',
+      :key_size     => true,
+    } }
+    it 'should fail' do
+      expect {
+        is_expected.to contain_file('/etc/ssl/certs/foo.cnf')
+      }.to raise_error(Puppet::Error, /"true" does not match/)
+    end
+  end
+
   context 'when using defaults' do
     let (:params) { {
       :country      => 'com',


### PR DESCRIPTION
The section `Integer()` was required as puppet returned 
```
Error: Could not set 'present' on ensure: Neither PUB key nor PRIV key: not enough data at 172:/etc/puppet/environments/intg/modules/openssl/manifests/certificate/x509.pp
```

When using
```
   ssl_pkey { $_key:
     ensure   => $ensure,
     password => $password,
    size     => 4096,
   }
```
It was running as `OpenSSL::PKey::RSA.new('4096')` (note the quotes).  I guess it is the type validation (`/newvalues /\d+/`) which return content as a string.


