### PR TITLE
Fix failure to load inifile causing Puppet agent to fail.

### DIFF
--- a/lib/puppet/provider/x509_cert/openssl.rb
+++ b/lib/puppet/provider/x509_cert/openssl.rb
@@ -1,5 +1,4 @@
 require 'pathname'
-require 'inifile'
 Puppet::Type.type(:x509_cert).provide(:openssl) do
   desc 'Manages certificates with OpenSSL'
 
@@ -37,6 +36,7 @@ Puppet::Type.type(:x509_cert).provide(:openssl) do
         cdata[k] = v
     end
 
+    require 'inifile'
     ini_file  = IniFile.load(resource[:template])
     ini_file.each do |section, parameter, value|
       return false if parameter == 'subjectAltName' and value.delete(' ').gsub(/^"|"$/, '') != altName.delete(' ').gsub(/^"|"$/, '')

--- a/spec/unit/puppet/provider/x509_cert/openssl_spec.rb
+++ b/spec/unit/puppet/provider/x509_cert/openssl_spec.rb
@@ -1,3 +1,4 @@
+require 'inifile'
 require 'puppet'
 require 'pathname'
 require 'puppet/type/x509_cert'


### PR DESCRIPTION
If the `inifile` gem isn't installed on the node we get the following error from Puppet agent:

> Error: Could not autoload puppet/provider/x509_cert/openssl: cannot load such file -- inifile
> Error: Could not autoload puppet/type/x509_cert: Could not autoload puppet/provider/x509_cert/openssl: cannot load such file -- inifile
> Error: Failed to apply catalog: Could not autoload puppet/type/x509_cert: Could not autoload puppet/provider/x509_cert/openssl: cannot load such file -- inifile

This happens so early in the process that we can't use Puppet to install the required gem.

This patch changes the code so that the inifile gem isn't loaded until it is actually needed. This has two benefits:

1. If the code that requires the inifile gem isn't actually used in this deployment, we don't need to install it.
2. If we need the `inifile` gem, we can install it through Puppet with the [`puppet_gem` provider](https://docs.puppetlabs.com/puppet/latest/reference/type.html#package-provider-puppet_gem).

(Note that installing the `inifile` gem through Puppet won't fix the failure on the first Puppet run, but subsequent runs (after the Gem is installed) will work.)