### PR TITLE
altnames can represent ip addresses

### DIFF
--- a/lib/puppet/provider/x509_cert/openssl.rb
+++ b/lib/puppet/provider/x509_cert/openssl.rb
@@ -39,7 +39,7 @@ Puppet::Type.type(:x509_cert).provide(:openssl) do
     require 'inifile'
     ini_file  = IniFile.load(resource[:template])
     ini_file.each do |section, parameter, value|
-      return false if parameter == 'subjectAltName' and value.delete(' ').gsub(/^"|"$/, '') != altName.delete(' ').gsub(/^"|"$/, '')
+      return false if parameter == 'subjectAltName' and value.delete(' ').gsub(/^"|"$/, '') != altName.delete(' ').gsub(/^"|"$/, '').gsub('IPAddress','IP')
       return false if parameter == 'commonName' and value != cdata['CN']
     end
     return true


### PR DESCRIPTION
When creating an ssl cert that uses an ip address as an altname the cert was being recreated every puppet run. This was due to the fact that the x509_cert provider recognizes the altname as "IP Address" but the cert.cnf requires that it is defined as such (where 127.0.0.1 is the desired ip):
`subjectAltName = IP:127.0.0.1`
This resulted in the provider thinking that the cert changed because "IPAddress:127.0.0.1" != "IP:127.0.0.1"