### PR TITLE
Add a hyphen to the version portion of regex

### DIFF
--- a/lib/facter/openssl_version.rb
+++ b/lib/facter/openssl_version.rb
@@ -2,7 +2,7 @@ Facter.add(:openssl_version) do
   setcode do
     if Facter::Util::Resolution.which('openssl')
       openssl_version = Facter::Util::Resolution.exec('openssl version 2>&1')
-      %r{^OpenSSL ([\w\.]+) ([\d\.]+) ([\w\.]+) ([\d\.]+)}.match(openssl_version)[1]
+      %r{^OpenSSL ([\w\.\-]+) ([\d\.]+) ([\w\.]+) ([\d\.]+)}.match(openssl_version)[1]
     end
   end
 end


### PR DESCRIPTION
In CentOS, openssl version command shows like `OpenSSL 1.0.1e-fips 11 Feb 2013`, so `([\w\.]+)` doesn't match it.