### PR TITLE
fixes #62 - error resolving openssl_version on RHEL 6

### DIFF
--- a/lib/facter/openssl_version.rb
+++ b/lib/facter/openssl_version.rb
@@ -2,7 +2,7 @@ Facter.add(:openssl_version) do
   setcode do
     if Facter::Util::Resolution.which('openssl')
       openssl_version = Facter::Util::Resolution.exec('openssl version 2>&1')
-      %r{^OpenSSL ([\w\.\-]+) ([\d\.]+) ([\w\.]+) ([\d\.]+)}.match(openssl_version)[1]
+      %r{^OpenSSL ([\w\.\-]+)([ ]+)([\d\.]+)([ ]+)([\w\.]+)([ ]+)([\d\.]+)}.match(openssl_version)[1]
     end
   end
 end

--- a/lib/facter/openssl_version.rb
+++ b/lib/facter/openssl_version.rb
@@ -2,7 +2,7 @@ Facter.add(:openssl_version) do
   setcode do
     if Facter::Util::Resolution.which('openssl')
       openssl_version = Facter::Util::Resolution.exec('openssl version 2>&1')
-      %r{^OpenSSL ([\w\.]+) ([\d\.]+) ([\w\.]+) ([\d\.]+)}.match(openssl_version)[1]
+      %r{^OpenSSL ([\w\.\-]+) ([\d\.]+) ([\w\.]+) ([\d\.]+)}.match(openssl_version)[1]
     end
   end
 end

--- a/spec/unit/openssl_version_spec.rb
+++ b/spec/unit/openssl_version_spec.rb
@@ -19,6 +19,17 @@ describe Facter::Util::Fact do
           }
         end
       end
+      describe "openssl_version rhel" do
+        context 'with value' do
+          before :each do
+            Facter::Util::Resolution.stubs(:which).with('openssl').returns(true)
+            Facter::Util::Resolution.stubs(:exec).with('openssl version 2>&1').returns('OpenSSL 1.0.1e-fips 11 Feb 2013')
+          end
+          it {
+            expect(Facter.value(:openssl_version)).to eq('1.0.1e-fips')
+          }
+        end
+      end
     end
   end
 end

--- a/spec/unit/openssl_version_spec.rb
+++ b/spec/unit/openssl_version_spec.rb
@@ -30,6 +30,17 @@ describe Facter::Util::Fact do
           }
         end
       end
+      describe "openssl_version centos" do
+        context 'with value' do
+          before :each do
+            Facter::Util::Resolution.stubs(:which).with('openssl').returns(true)
+            Facter::Util::Resolution.stubs(:exec).with('openssl version 2>&1').returns('OpenSSL 1.0.2g  1 Mar 2016')
+          end
+          it {
+            expect(Facter.value(:openssl_version)).to eq('1.0.2g')
+          }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #62 

RHEL 6:
```
$ openssl version
OpenSSL 1.0.1e-fips 11 Feb 2013
```

CentOS:
```
$ openssl version
OpenSSL 1.0.2g  1 Mar 2016
```