### PR TITLE
Added parameter to allow for extra openssl packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ class { '::openssl':
 }
 ```
 
+Specify openssl and compat package
+
+```puppet
+class { '::openssl':
+  package_name  => ['openssl', 'openssl-compat', ],
+}
+```
+
 ## Types and providers
 
 This module provides three types and associated providers to manage SSL keys and certificates.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,17 +3,20 @@
 # Installs openssl and ensures bundled certificate list is world readable.
 #
 # === Parameters
+#  [*package_name*]             openssl package name
 #  [*package_ensure*]           openssl package ensure
 #  [*ca_certificates_ensure*]   ca-certificates package ensure
 #
 # === Example
 #
 #   class { '::openssl':
+#     package_name           => 'openssl-othername',
 #     package_ensure         => latest,
 #     ca_certificates_ensure => latest,
 #   }
 #
 class openssl (
+  $package_name           = 'openssl',
   $package_ensure         = present,
   $ca_certificates_ensure = present,
 ){

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -2,7 +2,7 @@
 #
 # Sets up packages for openssl
 class openssl::packages {
-  package { 'openssl':
+  package { $openssl::package_name:
     ensure => $openssl::package_ensure,
   }
 

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -2,7 +2,8 @@
 #
 # Sets up packages for openssl
 class openssl::packages {
-  package { $openssl::package_name:
+  package { 'openssl':
+    name   => $openssl::package_name,
     ensure => $openssl::package_ensure,
   }
 


### PR DESCRIPTION
For many of my systems I also require the compat packages or the 32bit versions.  Adding the package name as a parameter seemed the cleanest way to permit that behavior.
