### PR TITLE
Error: Unknown authentication type 'dsa' when setting authentication

### DIFF
--- a/lib/puppet/type/ssl_pkey.rb
+++ b/lib/puppet/type/ssl_pkey.rb
@@ -16,8 +16,12 @@ Puppet::Type.newtype(:ssl_pkey) do
 
   newparam(:authentication) do
     desc "The authentication algorithm: 'rsa' or 'dsa'"
-    newvalues /[dr]sa/
+    newvalues :rsa, :dsa
     defaultto :rsa
+
+    munge do |val|
+      val.to_sym
+    end
   end
 
   newparam(:size) do


### PR DESCRIPTION
When setting the authentication in Puppet for a ssl_pkey :

```
ssl_pkey { "${ssl_dir}/${service_name}":
    ensure          => present,
    size            => 2048,
    authentication  => 'dsa',
    password        => 'test'
}
```

I get the following error : `Error: Unknown authentication type 'dsa' when setting authentication`

I tried with and without quotes/double quotes.

I use Puppet 3.8.5, with Ruby 1.8.7.

After looking at the code, it seems the comparison is done with a symbol :

```
  def self.generate_key(resource)
    if resource[:authentication] == :dsa
      OpenSSL::PKey::DSA.new(resource[:size])
    elsif resource[:authentication] == :rsa
      OpenSSL::PKey::RSA.new(resource[:size])
    else
      raise Puppet::Error,
        "Unknown authentication type '#{resource[:authentication]}'"
    end
end
```

Replacing `if resource[:authentication] == :dsa` by `if resource[:authentication].to_sym == :dsa` seems to fix the issue, but I am not sure it is the good way to do things.
