### PR TITLE
handle refresh (RE: #71)

### DIFF
--- a/lib/puppet/type/x509_cert.rb
+++ b/lib/puppet/type/x509_cert.rb
@@ -81,4 +81,8 @@ Puppet::Type.newtype(:x509_cert) do
   autorequire(:file) do
     self[:private_key]
   end
+
+  def refresh
+    provider.create
+  end
 end

--- a/lib/puppet/type/x509_request.rb
+++ b/lib/puppet/type/x509_request.rb
@@ -63,4 +63,8 @@ Puppet::Type.newtype(:x509_request) do
   autorequire(:file) do
     self[:private_key]
   end
+
+  def refresh
+    provider.create
+  end
 end

--- a/manifests/certificate/x509.pp
+++ b/manifests/certificate/x509.pp
@@ -194,6 +194,8 @@ define openssl::certificate::x509(
     password    => $password,
     force       => $force,
     require     => File[$_cnf],
+    subscribe   => File[$_cnf],
+    notify      => X509_cert[$_crt],
   }
 
   # Set owner of all files


### PR DESCRIPTION
This could very well be an abomination (sysadmin here), but this seems to work for us.
When using openssl::certificate::x509, if the config changes, the CSR and cert are regenerated.
