### PR TITLE
Add class to allow creating certificates as class parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ class { '::openssl':
 }
 ```
 
+Create certificates (see the x509 defined type):
+
+```puppet
+class { '::openssl::certificates':
+  x509_certs => { '/path/to/certificate.crt' => { ensure      => 'present',
+                                                  password    => 'j(D$',
+                                                  template    => '/other/path/to/template.cnf',
+                                                  private_key => '/there/is/my/private.key',
+                                                  days        => 4536,
+                                                  force       => false,},
+                  '/a/other/certificate.crt' => { ensure      => 'present', },
+                }
+}
+```
+
+
 ## Types and providers
 
 This module provides three types and associated providers to manage SSL keys and certificates.

--- a/manifests/certificates.pp
+++ b/manifests/certificates.pp
@@ -1,0 +1,29 @@
+# == Class: openssl::certificates
+#
+# Generates x509 certificates based on class parameters
+#
+# === Parameters
+#  [*x509_certs*]
+#
+# === Example
+#
+#   class { '::openssl::certificate':
+#     x509_certs => { '/path/to/certificate.crt' => {  ensure      => 'present',
+#                                                      password    => 'j(D$',
+#                                                      template    => '/other/path/to/template.cnf',
+#                                                      private_key => '/there/is/my/private.key',
+#                                                      days        => 4536,
+#                                                      force       => false,},
+#                     '/a/other/certificate.crt' => {  ensure      => 'present', },
+#                   }
+#   }
+#
+class openssl::certificates (
+  $x509_certs = {},
+){
+  validate_hash($x509_certs)
+
+  if $x509_certs {
+    ensure_resources('openssl::certificate::x509', $x509_certs)
+  }
+}

--- a/spec/classes/certificates_spec.rb
+++ b/spec/classes/certificates_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'openssl::certificates' do
+  let :params do
+    {
+      :x509_certs => { '/path/to/certificate.crt' => { 'ensure'      => 'present',
+                                                       'password'    => 'j(D$',
+                                                       'template'    => '/other/path/to/template.cnf',
+                                                       'private_key' => '/there/is/my/private.key',
+                                                       'days'        => 4536,
+                                                       'force'       => false,},
+                       '/a/other/certificate.crt' => { 'ensure'      => 'present', },
+                     }
+    }
+  end
+  it 'has certs' do expect {
+    is_expected.to have_openssl__certificate__x509_count(2)
+  }
+end


### PR DESCRIPTION
This should allow the creation of certificates as class parameters (mostly for users of ENCs)
