### PR TITLE
Changes to support unencrypted CSRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 log/
 .*.swp
 *~
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ log/
 .*.swp
 *~
 .idea/
+*.ipr
+*.iws
+*.iml
+

--- a/lib/puppet/provider/x509_request/openssl.rb
+++ b/lib/puppet/provider/x509_request/openssl.rb
@@ -34,22 +34,22 @@ Puppet::Type.type(:x509_request).provide(:openssl) do
   end
 
   def create
-    if resource[:password]
-      openssl(
-        'req', '-new',
-        '-key', resource[:private_key],
-        '-config', resource[:template],
-        '-out', resource[:path],
-        '-passin', "pass:#{resource[:password]}"
-      )
-    else
-      openssl(
+    cmd_args = [
         'req', '-new',
         '-key', resource[:private_key],
         '-config', resource[:template],
         '-out', resource[:path]
-      )
+    ]
+
+    if resource[:password]
+      cmd_args.push('-passin', "pass:#{resource[:password]}")
     end
+
+    if resource[:unencrypted]
+      cmd_args.push('-nodes')
+    end
+
+    openssl(cmd_args)
   end
 
   def destroy

--- a/lib/puppet/provider/x509_request/openssl.rb
+++ b/lib/puppet/provider/x509_request/openssl.rb
@@ -42,7 +42,8 @@ Puppet::Type.type(:x509_request).provide(:openssl) do
     ]
 
     if resource[:password]
-      cmd_args.push('-passin', "pass:#{resource[:password]}")
+      cmd_args.push('-passin')
+      cmd_args.push("pass:#{resource[:password]}")
     end
 
     if resource[:unencrypted]

--- a/lib/puppet/provider/x509_request/openssl.rb
+++ b/lib/puppet/provider/x509_request/openssl.rb
@@ -50,7 +50,7 @@ Puppet::Type.type(:x509_request).provide(:openssl) do
       cmd_args.push('-nodes')
     end
 
-    openssl(cmd_args)
+    openssl(*cmd_args)
   end
 
   def destroy

--- a/lib/puppet/provider/x509_request/openssl.rb
+++ b/lib/puppet/provider/x509_request/openssl.rb
@@ -46,7 +46,7 @@ Puppet::Type.type(:x509_request).provide(:openssl) do
       cmd_args.push("pass:#{resource[:password]}")
     end
 
-    if resource[:unencrypted]
+    if not resource[:encrypted]
       cmd_args.push('-nodes')
     end
 

--- a/lib/puppet/type/x509_request.rb
+++ b/lib/puppet/type/x509_request.rb
@@ -55,10 +55,10 @@ Puppet::Type.newtype(:x509_request) do
     defaultto :rsa
   end
 
-  newparam(:unencrypted, :boolean => true) do
+  newparam(:encrypted, :boolean => true) do
     desc 'Whether to generate the key unencrypted. This is needed by some applications like OpenLDAP'
     newvalues(:true, :false)
-    defaultto false
+    defaultto true
   end
 
   autorequire(:x509_cert) do

--- a/lib/puppet/type/x509_request.rb
+++ b/lib/puppet/type/x509_request.rb
@@ -55,6 +55,12 @@ Puppet::Type.newtype(:x509_request) do
     defaultto :rsa
   end
 
+  newparam(:unencrypted, :boolean => true) do
+    desc 'Whether to generate the key unencrypted. This is needed by some applications like OpenLDAP'
+    newvalues(:true, :false)
+    defaultto false
+  end
+
   autorequire(:x509_cert) do
     path = Pathname.new(self[:private_key])
     "#{path.dirname}/#{path.basename(path.extname)}"

--- a/manifests/certificate/x509.pp
+++ b/manifests/certificate/x509.pp
@@ -42,10 +42,10 @@
 #                     Directory must exist, defaults to $csr_dir/$title.csr
 #  [*key*]            override key path entirely.
 #                     Directory must exist, defaults to $key_dir/$title.key
-#  [*unencrypted*]    Flag requesting the exported key to be unencrypted by
+#  [*encrypted*]      Flag requesting the exported key to be unencrypted by
 #                     specifying the -nodes option during the CSR generation. Turning
-#                     of encryption is needed by some applications, such as OpenLDAP.
-#                     Defaults to false (key is encrypted)
+#                     off encryption is needed by some applications, such as OpenLDAP.
+#                     Defaults to true (key is encrypted)
 #
 # === Example
 #
@@ -101,6 +101,7 @@ define openssl::certificate::x509(
   Optional[String]               $password = undef,
   Boolean                        $force = true,
   String                         $cnf_tpl = 'openssl/cert.cnf.erb',
+  Boolean                        $encrypted = true,
   ) {
 
   $_key_owner = pick($key_owner, $owner)

--- a/manifests/certificate/x509.pp
+++ b/manifests/certificate/x509.pp
@@ -101,7 +101,7 @@ define openssl::certificate::x509(
   $password = undef,
   $force = true,
   $cnf_tpl = 'openssl/cert.cnf.erb',
-  $unencrypted = false,
+  $encrypted = true,
   ) {
 
   $_key_owner = pick($key_owner, $owner)
@@ -158,7 +158,7 @@ define openssl::certificate::x509(
   validate_string($key_mode)
   validate_string($password)
   validate_bool($force)
-  validate_bool($unencrypted)
+  validate_bool($encrypted)
   validate_re($ensure, '^(present|absent)$',
     "\$ensure must be either 'present' or 'absent', got '${ensure}'")
   validate_string($cnf_tpl)
@@ -199,7 +199,7 @@ define openssl::certificate::x509(
     private_key => $_key,
     password    => $password,
     force       => $force,
-    unencrypted => $unencrypted,
+    encrypted   => $encrypted,
     require     => File[$_cnf],
     subscribe   => File[$_cnf],
     notify      => X509_cert[$_crt],

--- a/manifests/certificate/x509.pp
+++ b/manifests/certificate/x509.pp
@@ -42,6 +42,10 @@
 #                     Directory must exist, defaults to $csr_dir/$title.csr
 #  [*key*]            override key path entirely.
 #                     Directory must exist, defaults to $key_dir/$title.key
+#  [*unencrypted*]    Flag requesting the exported key to be unencrypted by
+#                     specifying the -nodes option during the CSR generation. Turning
+#                     of encryption is needed by some applications, such as OpenLDAP.
+#                     Defaults to false (key is encrypted)
 #
 # === Example
 #
@@ -97,6 +101,7 @@ define openssl::certificate::x509(
   $password = undef,
   $force = true,
   $cnf_tpl = 'openssl/cert.cnf.erb',
+  $unencrypted = false,
   ) {
 
   $_key_owner = pick($key_owner, $owner)
@@ -153,6 +158,7 @@ define openssl::certificate::x509(
   validate_string($key_mode)
   validate_string($password)
   validate_bool($force)
+  validate_bool($unencrypted)
   validate_re($ensure, '^(present|absent)$',
     "\$ensure must be either 'present' or 'absent', got '${ensure}'")
   validate_string($cnf_tpl)
@@ -193,6 +199,7 @@ define openssl::certificate::x509(
     private_key => $_key,
     password    => $password,
     force       => $force,
+    unencrypted => $unencrypted,
     require     => File[$_cnf],
     subscribe   => File[$_cnf],
     notify      => X509_cert[$_crt],


### PR DESCRIPTION
Issue #83  is the upstream issue request for this pull request.  It adds a new field named `unencrypted` to the x509_req type and the Openssl::certificates::x509 class.  This in turns goes to the provider. When turned on (default is off to preserve existing behaviour), it will pass the `-nodes` argument to the underlying openssl command, resulting in a key that can be used by OpenLDAP. 