### PR TITLE
Add definitions to export PEM cert/key from PKCS12 container

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,33 @@ openssl::export::pkcs12 { 'foo':
 }
 ```
 
+### openssl::export::pem_cert
+
+This definition exports PEM certificates from a pkcs12 container:
+
+```puppet
+openssl::export::pem_cert { 'foo':
+  ensure   => 'present',
+  pfx_cert => '/here/is/my/certstore.pfx',
+  pem_cert => '/here/is/my/cert.pem',
+  in_pass  => 'my_pkcs12_password',
+}
+```
+
+### openssl::export::pem_key
+
+This definition exports PEM key from a pkcs12 container:
+
+```puppet
+openssl::export::pem_key { 'foo':
+  ensure   => 'present',
+  pfx_cert => '/here/is/my/certstore.pfx',
+  pem_key  => '/here/is/my/private.key',
+  in_pass  => 'my_pkcs12_password',
+  out_pass => 'my_pkey_password',
+}
+```
+
 ### openssl::dhparam
 
 This definition creates a dhparam PEM file:

--- a/manifests/export/pem_cert.pp
+++ b/manifests/export/pem_cert.pp
@@ -1,0 +1,43 @@
+# == Definition: openssl::export::pem_cert
+#
+# Export certificate(s) to PEM/x509 format
+#
+# == Parameters
+#   [*pfx_cert*]  - PFX certificate/key container
+#   [*pem_cert*]  - PEM/x509 certificate
+#   [*in_pass*]   - PFX password
+#
+define openssl::export::pem_cert(
+  $pfx_cert,
+  $pem_cert  = $title,
+  $ensure    = present,
+  $in_pass   = false,
+) {
+  case $ensure {
+    'present': {
+      $passin_opt = $in_pass ? {
+        false   => '',
+        default => "-passin pass:'${in_pass}'",
+      }
+
+      $cmd = [
+        'openssl pkcs12',
+        "-in ${pfx_cert}",
+        "-out ${pem_cert}",
+        '-nokeys',
+        $passin_opt,
+      ]
+
+      exec {"Export ${pfx_cert} to ${pem_cert}":
+        command => inline_template('<%= @cmd.join(" ") %>'),
+        path    => $::path,
+        creates => $pem_cert,
+      }
+    }
+    'absent': {
+      file {$pem_cert:
+        ensure => absent,
+      }
+    }
+  }
+}

--- a/manifests/export/pem_key.pp
+++ b/manifests/export/pem_key.pp
@@ -1,0 +1,51 @@
+# == Definition: openssl::export::pem_key
+#
+# Export a key to PEM format
+#
+# == Parameters
+#   [*pfx_cert*]  - PFX certificate/key container
+#   [*pem_key*]   - PEM certificate
+#   [*in_pass*]   - PFX container password
+#   [*out_pass*]  - PEM key password
+#
+define openssl::export::pem_key(
+  $pfx_cert,
+  $pem_key   = $title,
+  $ensure    = present,
+  $in_pass   = false,
+  $out_pass  = false,
+) {
+  case $ensure {
+    'present': {
+      $passin_opt = $in_pass ? {
+        false   => '',
+        default => "-passin pass:'${in_pass}'",
+      }
+
+      $passout_opt = $out_pass ? {
+        false   => '-nodes',
+        default => "-passout pass:'${out_pass}'",
+      }
+
+      $cmd = [
+        'openssl pkcs12',
+        "-in ${pfx_cert}",
+        "-out ${pem_key}",
+        '-nocerts',
+        $passin_opt,
+        $passout_opt,
+      ]
+
+      exec {"Export ${pfx_cert} to ${pem_key}":
+        command => inline_template('<%= @cmd.join(" ") %>'),
+        path    => $::path,
+        creates => $pem_key,
+      }
+    }
+    'absent': {
+      file {$pem_key:
+        ensure => absent,
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add openssl::export::pem_cert to export PEM certs from PKCS12.
Add openssl::export::pem_key to export PEM certs from PKCS12.
Update README.md to reflect this addition.