### PR TITLE
Make the $fastmode parameter for openssl::dhparam default to false.

### DIFF
--- a/manifests/dhparam.pp
+++ b/manifests/dhparam.pp
@@ -21,7 +21,7 @@ define openssl::dhparam(
   $owner = 'root',
   $group = 'root',
   $mode = '0644',
-  $fastmode = true,
+  $fastmode = false,
 ) {
 
   validate_absolute_path($path)


### PR DESCRIPTION
In lib/puppet/type/dhparam.rb, we set the default for the dhparam type
to false, so to keep konsistent, the default value for the define
should also be false.