### PR TITLE
Server certs generation flag

### DIFF
--- a/lib/puppet/provider/x509_cert/openssl.rb
+++ b/lib/puppet/provider/x509_cert/openssl.rb
@@ -65,17 +65,29 @@ Puppet::Type.type(:x509_cert).provide(:openssl) do
   end
 
   def create
-    options = [
-      'req',
-      '-config', resource[:template],
-      '-new', '-x509',
-      '-days', resource[:days],
-      '-key', resource[:private_key],
-      '-out', resource[:path],
-    ]
-    options << ['-passin', "pass:#{resource[:password]}",] if resource[:password]
-    options << ['-extensions', "req_ext",] if resource[:req_ext] != :false
-    openssl options
+    if resource[:is_server]
+      options = [ 'ca',
+        '-batch',
+        '-config', resource[:template],
+        '-days', resource[:days],
+        '-in', resource[:csr],
+        '-out', resource[:path],
+      ]
+      options << ['-extensions', "req_ext",] if resource[:req_ext] != :false
+      openssl options
+    else
+      options = [
+        'req',
+        '-config', resource[:template],
+        '-new', '-x509',
+        '-days', resource[:days],
+        '-key', resource[:private_key],
+        '-out', resource[:path],
+      ]
+      options << ['-passin', "pass:#{resource[:password]}",] if resource[:password]
+      options << ['-extensions', "req_ext",] if resource[:req_ext] != :false
+      openssl options
+    end
   end
 
   def destroy

--- a/lib/puppet/type/x509_cert.rb
+++ b/lib/puppet/type/x509_cert.rb
@@ -64,6 +64,26 @@ Puppet::Type.newtype(:x509_cert) do
     end
   end
 
+  newparam(:is_server, :boolean => true) do
+    desc 'Option to create a server certificate using openssl ca rather than a client certificate'
+    newvalues(:true, :false)
+    defaultto false
+  end
+
+  newparam(:csr) do
+    desc 'The path to the CSR if producing a server certificate'
+    defaultto do
+      csr = Pathname.new(@resource[:csr])
+      "#{csr.dirname}/#{csr.basename(csr.extname)}.pem"
+    end
+    validate do |value|
+      csr = Pathname.new(value)
+      unless csr.absolute?
+        raise ArgumentError, "CSR Path must be absolute: #{csr}"
+      end
+    end
+  end
+
   newparam(:authentication) do
     desc "The authentication algorithm: 'rsa' or 'dsa'"
     newvalues /[dr]sa/


### PR DESCRIPTION
Allows for creating server certificates. Initial commit only works on the x509_cert defined type. I did not pull it through to the openssl::certificates::x509 compound type yet. Would like your initial feedback first.