### PR TITLE
Add the x509_extensions directive to support SAN in certificate

### DIFF
--- a/templates/cert.cnf.erb
+++ b/templates/cert.cnf.erb
@@ -16,6 +16,7 @@ distinguished_name      = req_distinguished_name
 prompt                  = no
 <% if @altnames and not @altnames.empty? -%>
 req_extensions          = req_ext
+x509_extensions         = req_ext
 <% end -%>
 
 [ req_distinguished_name ]


### PR DESCRIPTION
Since version 58, Chrome no longer trusts certificates that don't contain a SAN. This means Chrome now displays a security error for certificates generated by puppet-openssl (even after you've added it to your trust store) because it doesn't include a SAN.

See #44 for the root cause.

This change appears to be all that's required to fix the issue. It tells OpenSSL to include the x509 data in the certificate, not only in the CSR.

Props @bijanvakili for investigation into this almost two years ago in #44.