### PR TITLE
Add dhparams regeneration in the event of a change in keysize

### DIFF
--- a/lib/puppet/provider/dhparam/openssl.rb
+++ b/lib/puppet/provider/dhparam/openssl.rb
@@ -14,14 +14,53 @@ Puppet::Type.type(:dhparam).provide(:openssl) do
       '-out', resource[:path],
       resource[:size]
     ]
-    if resource[:fastmode]
-      options.insert(1,'-dsaparam')
-    end
+    options.insert(1, '-dsaparam') if resource[:fastmode]
 
     openssl options
   end
 
   def destroy
     Pathname.new(resource[:path]).delete
+  end
+
+  def size
+    unless valid?
+      create
+      return
+    end
+    options = [
+      'dhparam',
+      '-in', resource[:path],
+      '-text'
+    ]
+    parse_openssl_dhparams_size(openssl(options))
+  end
+
+  def size=(_value)
+    create
+  end
+
+  def valid?
+    options = [
+      'dhparam',
+      '-in', resource[:path],
+      '-check'
+    ]
+
+    begin
+      output = openssl(options)
+      return true if output =~ /DH parameters appear to be ok./
+    rescue
+      Puppet.notice("dhparam file '#{name}' does not appear to contain valid dhparams, regenerating...")
+      return false
+    end
+  end
+
+  def parse_openssl_dhparams_size(output)
+      return 0 if output.nil?
+      dhparamsline = output.split("\n").first
+      dhparamsize = dhparamsline.match(/(\d+)/).captures[0]
+
+      dhparamsize
   end
 end

--- a/lib/puppet/type/dhparam.rb
+++ b/lib/puppet/type/dhparam.rb
@@ -13,10 +13,10 @@ Puppet::Type.newtype(:dhparam) do
     end
   end
 
-  newparam(:size) do
-    desc 'The key size'
+  newproperty(:size) do
+    desc 'Manage the dhparam key size'
     newvalues /\d+/
-    defaultto 512
+    defaultto 2048
     validate do |value|
       size = value.to_i
       if size <= 0 || value.to_s != size.to_s

--- a/spec/unit/puppet/provider/dhparam/openssl_spec.rb
+++ b/spec/unit/puppet/provider/dhparam/openssl_spec.rb
@@ -14,21 +14,33 @@ describe 'The openssl provider for the dhparam type' do
       subject.expects(:openssl).with([
         'dhparam',
         '-out', '/tmp/dhparam.pem',
-        512
+        2048
       ])
       subject.create
     end
   end
   context 'when setting size' do
     it 'should create dhpram with the proper options' do
-      resource[:size] = 2048
+      resource[:size] = 1024
       subject.expects(:openssl).with([
         'dhparam',
         '-out', '/tmp/dhparam.pem',
-        2048
+        1024
       ])
       subject.create
     end
+  end
+  context 'when the dhparam file already exists' do
+    it 'should check the validity of the existing key' do
+      resource[:size] = 128
+      subject.expects(:openssl).with([
+        'dhparam',
+        '-in', '/tmp/dhparam.pem',
+        '-check'
+      ])
+      subject.valid?
+    end
+
   end
   it 'should delete file' do
     Pathname.any_instance.expects(:delete)


### PR DESCRIPTION
- Regenerate dhparams if keysize changes (main motivation for this is LOGJAM
mitigation)
- Regenerate dhparams if the file on disk does not contain valid dhparams
- Change the default dhparams size to 2048