### PR TITLE
Fix spec tests

### DIFF
--- a/spec/defines/openssl_certificate_x509_spec.rb
+++ b/spec/defines/openssl_certificate_x509_spec.rb
@@ -13,7 +13,7 @@ describe 'openssl::certificate::x509' do
     it 'should fail' do
       expect {
         is_expected.to contain_file('/etc/ssl/certs/foo.cnf')
-      }.to raise_error(Puppet::Error, /got 'barz'/)
+      }.to raise_error(/got ['barz'|String]/)
     end
   end
 
@@ -402,7 +402,7 @@ describe 'openssl::certificate::x509' do
       ).with_content(
         /subjectAltName\s+=\s+"DNS: a\.com, DNS: b\.com, DNS: c\.com"/
       ).with_content(
-	/extendedKeyUsage\s+=\s+"serverAuth, clientAuth"/
+        /extendedKeyUsage\s+=\s+"serverAuth, clientAuth"/
       )
     }
 

--- a/spec/defines/openssl_dhparam_spec.rb
+++ b/spec/defines/openssl_dhparam_spec.rb
@@ -9,8 +9,8 @@ describe 'openssl::dhparam' do
     } }
     it 'should fail' do
       expect {
-              is_expected.to contain_file('/etc/ssl/dhparam.pem')
-      }.to raise_error(Puppet::Error, /got 'foo'/)
+        is_expected.to contain_file('/etc/ssl/dhparam.pem')
+      }.to raise_error(/got ['barz'|String]/)
     end
   end
   context 'when passing wrong value for ensure' do
@@ -87,7 +87,7 @@ describe 'openssl::dhparam' do
       )
     }
   end
-  
+
   context 'when using size' do
     let (:params) { {
       :path => '/etc/ssl/dhparam.pem',

--- a/templates/cert.cnf.erb
+++ b/templates/cert.cnf.erb
@@ -35,7 +35,7 @@ commonName                      = <%= @commonname %>
 emailAddress                    = <%= @email %>
 <% end -%>
 
-<% if $req_ext == true -%>
+<% if @req_ext == true -%>
 [ req_ext ]
 <% unless @altnames.empty? -%>
 subjectAltName = "<%= @altnames.collect! {|i| "DNS: #{i}" }.join(', ') -%>"
@@ -44,4 +44,3 @@ subjectAltName = "<%= @altnames.collect! {|i| "DNS: #{i}" }.join(', ') -%>"
 extendedKeyUsage = "<%= @extkeyusage.collect! {|x| "#{x}" }.join(', ') -%>"
 <% end -%>
 <% end -%>
-


### PR DESCRIPTION
* Fix variable reference in `templates/cert.cnf.erb` to fix spec tests.
* The error message for **Absolutepath** is different between Puppet 4 and Puppet 5, so spec tests can't check for the exception type anymore, just the error string.