### PR TITLE
Add ability to generate Elliptic Curve key pairs

### DIFF
--- a/lib/puppet/provider/ssl_pkey/openssl.rb
+++ b/lib/puppet/provider/ssl_pkey/openssl.rb
@@ -12,6 +12,8 @@ Puppet::Type.type(:ssl_pkey).provide(:openssl) do
       OpenSSL::PKey::DSA.new(resource[:size])
     elsif resource[:authentication] == :rsa
       OpenSSL::PKey::RSA.new(resource[:size])
+    elsif resource[:authentication] == :ec
+      OpenSSL::PKey::EC.new(resource[:curve]).generate_key
     else
       raise Puppet::Error,
         "Unknown authentication type '#{resource[:authentication]}'"

--- a/lib/puppet/provider/x509_cert/openssl.rb
+++ b/lib/puppet/provider/x509_cert/openssl.rb
@@ -10,6 +10,8 @@ Puppet::Type.type(:x509_cert).provide(:openssl) do
       OpenSSL::PKey::DSA.new(file, resource[:password])
     elsif resource[:authentication] == :rsa
       OpenSSL::PKey::RSA.new(file, resource[:password])
+    elsif resource[:authentication] == :ec
+      OpenSSL::PKey::EC.new(file, resource[:password])
     else
       raise Puppet::Error,
             "Unknown authentication type '#{resource[:authentication]}'"

--- a/lib/puppet/provider/x509_request/openssl.rb
+++ b/lib/puppet/provider/x509_request/openssl.rb
@@ -10,6 +10,8 @@ Puppet::Type.type(:x509_request).provide(:openssl) do
       OpenSSL::PKey::DSA.new(file, resource[:password])
     elsif resource[:authentication] == :rsa
       OpenSSL::PKey::RSA.new(file, resource[:password])
+    elsif resource[:authentication] == :ec
+      OpenSSL::PKey::EC.new(file, resource[:password])
     else
       raise Puppet::Error,
             "Unknown authentication type '#{resource[:authentication]}'"

--- a/lib/puppet/type/ssl_pkey.rb
+++ b/lib/puppet/type/ssl_pkey.rb
@@ -15,8 +15,8 @@ Puppet::Type.newtype(:ssl_pkey) do
   end
 
   newparam(:authentication) do
-    desc "The authentication algorithm: 'rsa' or 'dsa'"
-    newvalues :rsa, :dsa
+    desc "The authentication algorithm: 'rsa', 'dsa or ec'"
+    newvalues :rsa, :dsa, :ec
     defaultto :rsa
 
     munge do |val|
@@ -32,6 +32,11 @@ Puppet::Type.newtype(:ssl_pkey) do
     munge do |val|
       val.to_i
     end
+  end
+
+  newparam(:curve) do
+    desc 'The EC curve'
+    defaultto 'secp384r1'
   end
 
   newparam(:password) do

--- a/lib/puppet/type/x509_cert.rb
+++ b/lib/puppet/type/x509_cert.rb
@@ -65,8 +65,8 @@ Puppet::Type.newtype(:x509_cert) do
   end
 
   newparam(:authentication) do
-    desc "The authentication algorithm: 'rsa' or 'dsa'"
-    newvalues /[dr]sa/
+    desc "The authentication algorithm: 'rsa', 'dsa or ec'"
+    newvalues :rsa, :dsa, :ec
     defaultto :rsa
   end
 

--- a/lib/puppet/type/x509_request.rb
+++ b/lib/puppet/type/x509_request.rb
@@ -50,8 +50,8 @@ Puppet::Type.newtype(:x509_request) do
   end
 
   newparam(:authentication) do
-    desc "The authentication algorithm: 'rsa' or 'dsa'"
-    newvalues /[dr]sa/
+    desc "The authentication algorithm: 'rsa', 'dsa' or ec"
+    newvalues :rsa, :dsa, :ec
     defaultto :rsa
   end
 

--- a/spec/unit/puppet/provider/ssl_pkey/openssl_spec.rb
+++ b/spec/unit/puppet/provider/ssl_pkey/openssl_spec.rb
@@ -107,6 +107,38 @@ describe 'The openssl provider for the ssl_pkey type' do
     end
   end
 
+  context 'when setting authentication to ec' do
+    key = OpenSSL::PKey::EC.new('secp384r1').generate_key # For mocking
+
+    it 'should create an ec key' do
+      resource[:authentication] = :ec
+      OpenSSL::PKey::EC.expects(:new).with('secp384r1', nil).returns(key)
+      File.expects(:open).with('/tmp/foo.key', 'w')
+      subject.create
+    end
+
+    context 'when setting curve' do
+      it 'should create with given curve' do
+        resource[:authentication] = :ec
+        resource[:curve] = 'prime239v1'
+        OpenSSL::PKey::EC.expects(:new).with('prime239v1', nil).returns(key)
+        File.expects(:open).with('/tmp/foo.key', 'w')
+        subject.create
+      end
+    end
+
+    context 'when setting password' do
+      it 'should create with given password' do
+        resource[:authentication] = :ec
+        resource[:password] = '2x$5{'
+        OpenSSL::PKey::EC.expects(:new).with('secp384r1').returns(key)
+        OpenSSL::Cipher.expects(:new).with('des3')
+        File.expects(:open).with('/tmp/foo.key', 'w')
+        subject.create
+      end
+    end
+  end
+
   it 'should delete files' do
     Pathname.any_instance.expects(:delete)
     subject.destroy

--- a/spec/unit/puppet/type/ssl_pkey_spec.rb
+++ b/spec/unit/puppet/type/ssl_pkey_spec.rb
@@ -25,11 +25,18 @@ describe Puppet::Type.type(:ssl_pkey) do
     }.to raise_error(Puppet::Error, /Invalid value :foo/)
   end
 
+  it 'should accept an curve' do
+    subject[:curve] = :secp384r1
+    expect(subject[:curve]).to eq(:secp384r1)
+  end
+
   it 'should accept a valid authentication' do
     subject[:authentication] = :rsa
     expect(subject[:authentication]).to eq(:rsa)
     subject[:authentication] = :dsa
     expect(subject[:authentication]).to eq(:dsa)
+    subject[:authentication] = :ec
+    expect(subject[:authentication]).to eq(:ec)
   end
 
   it 'should not accept an invalid authentication' do

--- a/spec/unit/puppet/type/x509_cert_spec.rb
+++ b/spec/unit/puppet/type/x509_cert_spec.rb
@@ -68,6 +68,8 @@ describe Puppet::Type.type(:x509_cert) do
     expect(subject[:authentication]).to eq(:rsa)
     subject[:authentication] = :dsa
     expect(subject[:authentication]).to eq(:dsa)
+    subject[:authentication] = :ec
+    expect(subject[:authentication]).to eq(:ec)
   end
 
   it 'should not accept an invalid authentication' do

--- a/spec/unit/puppet/type/x509_request_spec.rb
+++ b/spec/unit/puppet/type/x509_request_spec.rb
@@ -57,6 +57,8 @@ describe Puppet::Type.type(:x509_request) do
     expect(subject[:authentication]).to eq(:rsa)
     subject[:authentication] = :dsa
     expect(subject[:authentication]).to eq(:dsa)
+    subject[:authentication] = :ec
+    expect(subject[:authentication]).to eq(:ec)
   end
 
   it 'should not accept an invalid authentication' do


### PR DESCRIPTION
This change adds the ability to generate EC key pairs. There is a default curve secp384r1. The list of curves is not pre enumerated for validation as the list of possible curves is way too long. And it would require code changes when new curves are added.