### PR TITLE
Allow openssl_version regex to match more FIPS versions

### DIFF
--- a/lib/facter/openssl_version.rb
+++ b/lib/facter/openssl_version.rb
@@ -2,7 +2,7 @@ Facter.add(:openssl_version) do
   setcode do
     if Facter::Util::Resolution.which('openssl')
       openssl_version = Facter::Util::Resolution.exec('openssl version 2>&1')
-      matches = %r{^OpenSSL ([\w\.\-]+)([ ]+)([\d\.]+)([ ]+)([\w\.]+)([ ]+)([\d\.]+)}.match(openssl_version)
+      matches = %r{^OpenSSL ([\w\.\-]+)( FIPS)?([ ]+)([\d\.]+)([ ]+)([\w\.]+)([ ]+)([\d\.]+)}.match(openssl_version)
       matches[1] if matches
     end
   end

--- a/spec/unit/openssl_version_spec.rb
+++ b/spec/unit/openssl_version_spec.rb
@@ -52,6 +52,17 @@ describe Facter.fact(:openssl_version) do
           }
         end
       end
+      describe 'openssl_version rhel8' do
+        context 'with value' do
+          before :each do
+            allow(Facter::Util::Resolution).to receive(:which).with('openssl').and_return(true)
+            allow(Facter::Util::Resolution).to receive(:exec).with('openssl version 2>&1').and_return('OpenSSL 1.1.1c FIPS  28 May 2019')
+          end
+          it {
+            expect(Facter.value(:openssl_version)).to eq('1.1.1c')
+          }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
el8 may have an OpenSSL version that doesn't match the current version regex,
e.g. `OpenSSL 1.1.1c FIPS 28 May 2019`. With this PR the regex now allows the
version string to contain ` FIPS` between the version number and date.

``` ruby
openssl_version = 'OpenSSL 1.1.1c FIPS  28 May 2019'
%r{^OpenSSL ([\w\.\-]+)( FIPS)?([ ]+)([\d\.]+)([ ]+)([\w\.]+)([ ]+)([\d\.]+)}.match(openssl_version)[1]
# => "1.1.1c"
```