### PR TITLE
add support for OpenBSD

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,1 +1,3 @@
 ---
+
+openssl::package_name: 'openssl'

--- a/data/os/OpenBSD.yaml
+++ b/data/os/OpenBSD.yaml
@@ -1,0 +1,5 @@
+---
+
+# on openbsd libressl is used which is part of the OS
+# there is no libressl package available.
+openssl::package_name: ~

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,7 @@
 #   }
 #
 class openssl (
-  String[1]                 $package_name           = 'openssl',
+  Optional[String[1]]       $package_name           = undef,
   Enum['present', 'absent'] $package_ensure         = present,
   Enum['present', 'absent'] $ca_certificates_ensure = present,
 ){

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -4,9 +4,11 @@
 class openssl::packages {
   assert_private()
 
-  package { 'openssl':
-    ensure => $openssl::package_ensure,
-    name   => $openssl::package_name,
+  if $openssl::package_name {
+    package { 'openssl':
+      ensure => $openssl::package_ensure,
+      name   => $openssl::package_name,
+    }
   }
 
   if $::osfamily == 'Debian' or (

--- a/metadata.json
+++ b/metadata.json
@@ -44,6 +44,13 @@
         "6",
         "7"
       ]
+    },
+    {
+      "operatingsystem": "OpenBSD",
+      "operatingsystemrelease": [
+        "6.7",
+        "6.8"
+      ]
     }
   ],
   "requirements": [

--- a/spec/classes/openssl_spec.rb
+++ b/spec/classes/openssl_spec.rb
@@ -7,7 +7,17 @@ describe 'openssl' do
 
       it { is_expected.to compile.with_all_deps }
 
-      it { is_expected.to contain_package('openssl').with_ensure('present') }
+      context 'on OpenBSD', if: facts[:osfamily] == 'OpenBSD' do
+        it { is_expected.to contain_package('openssl') }
+      end
+
+      context 'on not OpenBSD', if: facts[:osfamily] != 'OpenBSD' do
+        it {
+          is_expected.to contain_package('openssl')
+            .with_ensure('present')
+            .with_name('openssl')
+        }
+      end
 
       context 'on Debian', if: facts[:osfamily] == 'Debian' do
         it { is_expected.to contain_package('ca-certificates') }


### PR DESCRIPTION
* add OpenBSD to supported in metadata.json
* make package_name optional, since OpenBSD installs libressl
  which part of the system, not available as package
* adapt spec tests for OpenBSD without package installation
* add spec test check for package name to be installed