### PR TITLE
add class to generate configs

### DIFF
--- a/data/os/OpenBSD.yaml
+++ b/data/os/OpenBSD.yaml
@@ -3,3 +3,4 @@
 # on openbsd libressl is used which is part of the OS
 # there is no libressl package available.
 openssl::package_name: ~
+openssl::configs::group: 'wheel'

--- a/manifests/configs.pp
+++ b/manifests/configs.pp
@@ -76,10 +76,10 @@ class openssl::configs (
 
   $conffiles.each | String $filename, Hash $vals| {
     file { $filename:
-      ensure  => pick($vals['ensure'],'present'),
-      owner   => pick($vals['owner'],$owner),
-      group   => pick($vals['group'],$group),
-      mode    => pick($vals['mode'],$mode),
+      ensure  => pick($vals['ensure'], 'present'),
+      owner   => pick($vals['owner'], $owner),
+      group   => pick($vals['group'], $group),
+      mode    => pick($vals['mode'], $mode),
       content => epp('openssl/cert.cnf.epp', {
         country           => $country,
         state             => $state,

--- a/manifests/configs.pp
+++ b/manifests/configs.pp
@@ -74,7 +74,7 @@ class openssl::configs (
   File<| tag=='openssl-configs' |> -> X509_cert<| |>
   File<| tag=='openssl-configs' |> -> X509_request<| |>
 
-  $conffiles.each | String $filename, Hash $vals| {
+  $conffiles.each |String $filename, Hash $vals| {
     file { $filename:
       ensure  => pick($vals['ensure'], 'present'),
       owner   => pick($vals['owner'], $owner),

--- a/manifests/configs.pp
+++ b/manifests/configs.pp
@@ -69,11 +69,6 @@ class openssl::configs (
   Hash              $conffiles         = {},
 ){
 
-  # dpendencies: ensure config file is generated before potential usage
-  File<| tag=='openssl-configs' |> -> Ssl_pkey<| |>
-  File<| tag=='openssl-configs' |> -> X509_cert<| |>
-  File<| tag=='openssl-configs' |> -> X509_request<| |>
-
   $conffiles.each |String $filename, Hash $vals| {
     file { $filename:
       ensure  => pick($vals['ensure'], 'present'),

--- a/manifests/configs.pp
+++ b/manifests/configs.pp
@@ -94,7 +94,8 @@ class openssl::configs (
         extendedkeyusages => $extendedkeyusages,
         keyusages         => $keyusages,
         subjectaltnames   => $subjectaltnames,
-      } + delete($vals,['ensure','owner','group','mode']) ),
+      } + delete($vals,['ensure', 'owner', 'group', 'mode']),
+    ),
       tag     => 'openssl-configs',
     }
   }

--- a/manifests/configs.pp
+++ b/manifests/configs.pp
@@ -1,0 +1,101 @@
+# == Class: openssl::configs
+#
+# Generates openssl.conf files using defaults
+#
+# === Parameters
+# [*owner*]
+#   default owner for the configuration files
+# [*group*]
+#   default group for the configuration files
+# [*mode*]
+#   default mode for the configuration files
+# [*country*]
+#   default value for country
+# [*state*]
+#   default value for state
+# [*locality*]
+#   default value for locality
+# [*organization*]
+#   default value for organization
+# [*unit*]
+#   default value for unit
+# [*email*]
+#   default value for email
+# [*default_bits*]
+#   default key size to generate
+# [*default_md*]
+#   default message digest to use
+# [*default_keyfile*]
+#   default name for the keyfile
+# [*basicconstraints*]
+#   version 3 certificate extension basic constraints
+# [*extendedkeyusages*]
+#   version 3 certificate extension extended key usage
+# [*keyusages*]
+#   version 3 certificate extension key usage
+# [*subjectaltnames*]
+#   version 3 certificate extension for alternative names
+#   currently supported are IP (v4) and DNS
+# [*conffiles*]
+#   config files to generate
+#
+# === Example
+#
+#   class { '::openssl::configs':
+#     conffiles => { '/path/to/openssl.conf' => { ensure     => 'present',
+#                                                 commonname => 'somewhere.org',},
+#                    '/a/other/openssl.conf' => { ensure     => 'present',
+#                                                 commonname => 'somewhere.else.org' },
+#                   }
+#   }
+#
+class openssl::configs (
+  String            $owner             = 'root',
+  String            $group             = 'root',
+  String            $mode              = '0640',
+  Optional[String]  $country           = undef,
+  Optional[String]  $state             = undef,
+  Optional[String]  $locality          = undef,
+  Optional[String]  $organization      = undef,
+  Optional[String]  $unit              = undef,
+  Optional[String]  $email             = undef,
+  Integer           $default_bits      = 4096,
+  String            $default_md        = 'sha512',
+  String            $default_keyfile   = 'privkey.pem',
+  Optional[Array]   $basicconstraints  = undef,
+  Optional[Array]   $extendedkeyusages = undef,
+  Optional[Array]   $keyusages         = undef,
+  Optional[Array]   $subjectaltnames   = undef,
+  Hash              $conffiles         = {},
+){
+
+  # dpendencies: ensure config file is generated before potential usage
+  File<| tag=='openssl-configs' |> -> Ssl_pkey<| |>
+  File<| tag=='openssl-configs' |> -> X509_cert<| |>
+  File<| tag=='openssl-configs' |> -> X509_request<| |>
+
+  $conffiles.each | String $filename, Hash $vals| {
+    file { $filename:
+      ensure  => pick($vals['ensure'],'present'),
+      owner   => pick($vals['owner'],$owner),
+      group   => pick($vals['group'],$group),
+      mode    => pick($vals['mode'],$mode),
+      content => epp('openssl/cert.cnf.epp', {
+        country           => $country,
+        state             => $state,
+        locality          => $locality,
+        organization      => $organization,
+        unit              => $unit,
+        email             => $email,
+        default_bits      => $default_bits,
+        default_md        => $default_md,
+        default_keyfile   => $default_keyfile,
+        basicconstraints  => $basicconstraints,
+        extendedkeyusages => $extendedkeyusages,
+        keyusages         => $keyusages,
+        subjectaltnames   => $subjectaltnames,
+      } + delete($vals,['ensure','owner','group','mode']) ),
+      tag     => 'openssl-configs',
+    }
+  }
+}

--- a/spec/classes/configs_spec.rb
+++ b/spec/classes/configs_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'openssl::configs' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let :params do
+        {
+          country: 'CH',
+          organization: 'Existing Ltd',
+          conffiles: {
+            '/path/to/openssl.conf' =>  { 'country' => 'US', 'commonname' => 'servername.xyz.org' },
+            '/other/path/to/openssl.conf' => { 'group' => 'vpn', 'commonname' => ['test.ch', 'test2.ch'] },
+            '/absent.conf' => { 'ensure' => 'absent', 'commonname' => 'blah' },
+          },
+        }
+      end
+
+      it { is_expected.to compile }
+
+      it {
+        is_expected.to contain_file('/path/to/openssl.conf')
+          .with_ensure('present')
+          .with_owner('root')
+          .with_mode('0640')
+      }
+      it {
+        is_expected.to contain_file('/other/path/to/openssl.conf')
+          .with_ensure('present')
+          .with_owner('root')
+          .with_group('vpn')
+          .with_mode('0640')
+      }
+      it {
+        is_expected.to contain_file('/absent.conf')
+          .with_ensure('absent')
+      }
+    end
+  end
+end

--- a/templates/cert.cnf.epp
+++ b/templates/cert.cnf.epp
@@ -1,0 +1,82 @@
+<%- | String                         $country,
+      Optional[String]               $state        = undef,
+      Optional[String]               $locality     = undef,
+      String                         $organization,
+      Optional[String]               $unit         = undef,
+      Variant[String, Array[String]] $commonname,
+      Optional[String]               $email        = undef,
+      Integer                        $default_bits,
+      String                         $default_md,
+      String                         $default_keyfile,
+      Optional[Array]                $basicconstraints  = undef,
+      Optional[Array]                $extendedkeyusages = undef,
+      Optional[Array]                $keyusages         = undef,
+      Optional[Array]                $subjectaltnames   = undef,
+| -%>
+
+# file managed by puppet
+#
+
+# This definition stops the following lines choking if HOME isn't
+# defined.
+HOME                    = .
+RANDFILE                = $ENV::HOME/.rnd
+
+[ req ]
+default_bits            = <%= $default_bits %>
+default_md              = <%= $default_md %>
+default_keyfile         = <%= $default_keyfile %>
+distinguished_name      = req_distinguished_name
+prompt                  = no
+
+<% if $basicconstraints or $extendedkeyusages or $keyusages or $subjectaltnames {-%>
+# extensions
+req_extensions     = v3_req
+<% } -%>
+
+[ req_distinguished_name ]
+countryName                     = <%= $country %>
+<% if $state { -%>
+stateOrProvinceName             = <%= $state %>
+<% } -%>
+<% if $locality { -%>
+localityName                    = <%= $locality %>
+<% } -%>
+organizationName                = <%= $organization %>
+<% if $unit { -%>
+organizationalUnitName          = <%= $unit %>
+<% } -%>
+<% if $commonname =~ Array[String] { -%>
+  <%- $commonname.each |Integer $index, String $v| { -%>
+     <%- %><%= $index %>.commonName    = <%= $v %>
+  <%- } -%>
+<% } else { -%>
+commonName                      = <%= $commonname %>
+<% } -%>
+<% if $email { -%>
+emailAddress                    = <%= $email %>
+<% } -%>
+
+<% if $basicconstraints or $extendedkeyusages or $keyusages or $subjectaltnames {-%>
+  <%- %>[ v3_req ]
+  <%- if $basicconstraints { -%>
+    <%- %>basicConstraints  = <%= $basicconstraints.join(', ') %>
+  <%- } -%>
+  <%- if $extendedkeyusages { -%>
+    <%- %>extendedKeyUsage  = <%= $extendedkeyusages.join(', ') %>
+  <%- } -%>
+  <%- if $keyusages { -%>
+    <%- %>keyUsage          = <%= $keyusages.join(', ') %>
+  <%- } -%>
+  <%- if $subjectaltnames { -%>
+    <%- %>subjectAltName    = @alt_names
+    <%- %>[ alt_names ]
+    <%- $subjectaltnames.each |Integer $i, String $n | { -%>
+      <%- if $n =~ /^\d+.\d+.\d+.\d+$/ { -%>
+        <%- %>IP.<%= $i %> = <%= $n %>
+      <%- } else { -%>
+        <%- %>DNS.<%= $i %> = <%= $n %>
+      <%- } -%>
+    <%- } -%>
+  <%- } -%>
+<% } -%>


### PR DESCRIPTION
The new class openssl::configs create openssl.conf files.
The generation bases on a new .epp template since epp can
use parameters which was easier to integrate.

closes: #41