### PR TITLE
readd dependencies to class to generate configs

### DIFF
--- a/manifests/configs.pp
+++ b/manifests/configs.pp
@@ -69,6 +69,11 @@ class openssl::configs (
   Hash              $conffiles         = {},
 ){
 
+  # dpendencies: ensure config file is generated before potential usage
+  File<| tag=='openssl-configs' |> -> Ssl_pkey<| |>
+  File<| tag=='openssl-configs' |> -> X509_cert<| |>
+  File<| tag=='openssl-configs' |> -> X509_request<| |>
+
   $conffiles.each |String $filename, Hash $vals| {
     file { $filename:
       ensure  => pick($vals['ensure'], 'present'),


### PR DESCRIPTION
That was a bit fast to remove...

this reverts ae510aabcd72c60080c698687f8cbaa5402c98ec
from pull request #116 (remove dependencies since we have autorequire)
and adds the dependencies between openssl config file and cert generations.

the autorequire mentioned in the the original commit, meant the
newly available autorequire in the defined types. But that one is
an autorequire for the directory where we put the file to generate, not
the configuration file !