### PR TITLE
incorrect behaviour of cert_aia_caissuers if file does not exists

### DIFF
--- a/lib/puppet/functions/cert_aia_caissuers.rb
+++ b/lib/puppet/functions/cert_aia_caissuers.rb
@@ -43,5 +43,8 @@ Puppet::Functions.create_function(:cert_aia_caissuers) do
       end
     end
     value
+  rescue => details
+    warn "Function cert_aia_caissuers failed to evaluate on #{certfile}. Caused by #{details}"
+    value
   end
 end

--- a/spec/functions/cert_aia_caissuers_spec.rb
+++ b/spec/functions/cert_aia_caissuers_spec.rb
@@ -15,6 +15,12 @@ describe 'cert_aia_caissuers' do
     is_expected.to run.with_params(true).and_raise_error(ArgumentError)
   end
 
+  context 'when the argument does not exists' do
+    it 'returns nil if cert does not exists or readable' do
+      is_expected.to run.with_params('/path/to/cert').and_return(nil)
+    end
+  end
+
   context 'when the argument is correct' do
     let(:cert) { OpenSSL::X509::Certificate.new }
 


### PR DESCRIPTION
In the case of deferred evaluation of cert_aia_caissuers, when the argument does not point to an existing and readable file, the function will fail and stop the agent.

This adds an appropriate test case and fix for this issue.